### PR TITLE
Additional updates to GI v3.2 supported UC plugins

### DIFF
--- a/public/data/connections.json
+++ b/public/data/connections.json
@@ -104,7 +104,7 @@
                         {
                             "method_key":"Universal Connector",
                             "supported_versions": ["latest"],
-                            "download_url":"https://github.com/IBM/universal-connectors/releases/download/v1.0.0/S3OverCloudwatchLogsPackage.zip"
+                            "download_url":"https://github.com/IBM/universal-connectors/releases/download/v1.2.0/S3OverCloudwatchLogsPackage.zip"
                         }
                     ]
                 }
@@ -202,6 +202,54 @@
             ]
         },
         {
+            "supported_since": "3.2.0",
+            "database_name": "CouchDB",
+            "environments_supported": [
+                {
+                    "environment_name": "On-premise or IaaS",
+                    "methods_supported": [
+                        {
+                            "method_key":"Universal Connector",
+                            "supported_versions": ["3.2.2"],
+                            "download_url":"https://github.com/IBM/universal-connectors/releases/download/v1.2.0/CouchdbOverFilebeatPackage.zip"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "supported_since": "3.2.0",
+            "database_name": "DocumentDB",
+            "environments_supported": [
+                {
+                    "environment_name": "AWS (Database as a Service)",
+                    "methods_supported": [
+                        {
+                            "method_key":"Universal Connector",
+                            "supported_versions": ["4.0+"],
+                            "download_url":"https://github.com/IBM/universal-connectors/releases/download/v1.2.0/DocumentDBOverCloudwatchPackage.zip"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "supported_since": "3.2.0",
+            "database_name": "Greenplum",
+            "environments_supported": [
+                {
+                    "environment_name": "On-premise or IaaS",
+                    "methods_supported": [
+                        {
+                            "method_key":"Universal Connector",
+                            "supported_versions": ["6.21.0+"],
+                            "download_url":"https://github.com/IBM/universal-connectors/releases/download/v1.2.0/GreenplumdbOverFilebeatPackage.zip"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "supported_since": "3.1.0",
             "database_name": "HDFS",
             "environments_supported": [
@@ -211,7 +259,23 @@
                         {
                             "method_key":"Universal Connector",
                             "supported_versions": ["3.1+"],
-                            "download_url":"https://github.com/IBM/universal-connectors/releases/download/v1.2.0/HDFSOverFilebeatPackage.zip"
+                            "download_url":"https://github.com/IBM/universal-connectors/releases/download/v1.2.0/HdfsOverFilebeatPackage.zip"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "supported_since": "3.2.0",
+            "database_name": "MariaDB",
+            "environments_supported": [
+                {
+                    "environment_name": "On-premise or IaaS",
+                    "methods_supported": [
+                        {
+                            "method_key":"Universal Connector",
+                            "supported_versions": ["10.6+"],
+                            "download_url":"https://github.com/IBM/universal-connectors/releases/download/v1.2.0/MariaDBOverFilebeatPackage.zip"
                         }
                     ]
                 }
@@ -227,7 +291,7 @@
                         {
                             "method_key":"Universal Connector",
                             "supported_versions": ["4.2","4.4"],
-                            "download_url":"https://github.com/IBM/universal-connectors/releases/download/v1.0.0/MongodbOverFilebeatPackage.zip"
+                            "download_url":"https://github.com/IBM/universal-connectors/releases/download/v1.2.0/MongodbOverFilebeatPackage.zip"
                         }
                     ]
                 },
@@ -269,6 +333,22 @@
                             "method_key":"Universal Connector",
                             "supported_versions": ["5.7.31-34"],
                             "download_url":"https://github.com/IBM/universal-connectors/releases/download/v1.2.0/MysqlPerconaOverFilebeatPackage.zip"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "supported_since": "3.2.0",
+            "database_name": "Neptune",
+            "environments_supported": [
+                {
+                    "environment_name": "AWS (Database as a Service)",
+                    "methods_supported": [
+                        {
+                            "method_key":"Universal Connector",
+                            "supported_versions": ["1.1+"],
+                            "download_url":"https://github.com/IBM/universal-connectors/releases/download/v1.2.0/NeptuneOverCloudWatchPackage.zip"
                         }
                     ]
                 }


### PR DESCRIPTION
- Added: CouchDB, DocumentDB, MariaDB, Neptune, and Greenplum
- Fixed URL for HDFS