### PR TITLE
MariaDb 10.6 database version support update

### DIFF
--- a/public/data/connections.json
+++ b/public/data/connections.json
@@ -1676,6 +1676,7 @@
                 "MariaDB 10.3",
                 "MariaDB 10.4",
                 "MariaDB 10.5",
+                "MariaDB 10.6",
                 "MariaDB 5.5",
                 "MariaDB 5.6"
               ],

--- a/public/data/connections.yaml
+++ b/public/data/connections.yaml
@@ -1128,6 +1128,7 @@ supported_databases:
       - MariaDB 10.3
       - MariaDB 10.4
       - MariaDB 10.5
+      - MariaDB 10.6
       - MariaDB 5.5
       - MariaDB 5.6
       supported_operating_systems:


### PR DESCRIPTION
Per GDP PM, MariaDb version 10.6 is now supported. Updating to reflect what we now support.