### PR TITLE
GRD-94140: remove raw data link and add title

### DIFF
--- a/src/components/MainPage.js
+++ b/src/components/MainPage.js
@@ -14,8 +14,6 @@ import DatasourceModal from "./DataSourceModal/DataSourceModal";
 import MainPageCard from "./MainPageComponents/MainPageCard";
 import MainPageSearchBar from "./MainPageComponents/MainPageSearchBar";
 import MainPageDropdown from "./MainPageComponents/MainPageDropDown";
-// import MainPageLinks from "./MainPageComponents/MainPageLinks";
-// import MainPageTitle from "./MainPageComponents/MainPageTitle";
 import MainPageHeader from "./MainPageComponents/MainPageHeader";
 import { BLOCK_CLASS, PRODUCTS } from "../helpers/consts";
 

--- a/src/components/MainPage.js
+++ b/src/components/MainPage.js
@@ -14,7 +14,9 @@ import DatasourceModal from "./DataSourceModal/DataSourceModal";
 import MainPageCard from "./MainPageComponents/MainPageCard";
 import MainPageSearchBar from "./MainPageComponents/MainPageSearchBar";
 import MainPageDropdown from "./MainPageComponents/MainPageDropDown";
-import MainPageLinks from "./MainPageComponents/MainPageLinks";
+// import MainPageLinks from "./MainPageComponents/MainPageLinks";
+// import MainPageTitle from "./MainPageComponents/MainPageTitle";
+import MainPageHeader from "./MainPageComponents/MainPageHeader";
 import { BLOCK_CLASS, PRODUCTS } from "../helpers/consts";
 
 import "./../styles/connection_doc.scss";
@@ -66,7 +68,8 @@ export default function MainPage() {
     <>
       {/* Main Container when Loaded */}
       <div className="MainPageWrapper">
-        <MainPageLinks />
+        <MainPageHeader />
+        
 
         <div className="mainPageTopHolder">
           {/* Search Box */}

--- a/src/components/MainPageComponents/MainPageHeader.js
+++ b/src/components/MainPageComponents/MainPageHeader.js
@@ -1,0 +1,13 @@
+import React from "react";
+import MainPageTitle from "./MainPageTitle";
+import MainPageLinks from "./MainPageLinks";
+
+
+export default function MainPageHeader() {
+  return (
+    <div className="main-page-header">      
+      <MainPageTitle />
+      <MainPageLinks />
+    </div>
+  );
+}

--- a/src/components/MainPageComponents/MainPageLinks.js
+++ b/src/components/MainPageComponents/MainPageLinks.js
@@ -3,17 +3,9 @@ import React from "react";
 
 export default function MainPageLinks() {
   return (
-    <div className="links_div">
+    <div className="links_div" >      
       <a
-        className="raw-data-link"
-        href={process.env.PUBLIC_URL + "/data/connections.json"}
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        Raw Data
-      </a>
-      <a
-        className="raw-data-link"
+        className="main-page-data-link"
         href="https://github.com/IBM/guardium-supported-datasources/issues/new"
         rel="noopener noreferrer"
         target="_blank"

--- a/src/components/MainPageComponents/MainPageTitle.js
+++ b/src/components/MainPageComponents/MainPageTitle.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+
+export default function MainPageTitle() {
+  return (
+    <div>      
+      <h1>Guardium Supported Datasources</h1>
+    </div>
+  );
+}

--- a/src/styles/connection_doc.scss
+++ b/src/styles/connection_doc.scss
@@ -32,15 +32,15 @@
   margin-bottom: "5px";
 }
 
-.raw-data-link {
+.main-page-data-link {
   right: 2rem;
   top: 0.5rem;
   color: #333333;
-  padding-bottom: 1rem;
-  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  padding-top: 1rem;
 }
 
-.raw-data-link:hover {
+.main-page-data-link:hover {
   color: #9e9e9e;
 }
 
@@ -55,6 +55,13 @@
   padding-bottom: 1rem;
 }
 
+.main-page-header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding-bottom: 12px;
+
+}
 .mainPageDivider {
   margin: 0;
   padding: 0;
@@ -298,8 +305,9 @@ td.uk-background-muted {
 
 .links_div {
   display: flex;
-  flex-direction: row;
-  justify-content: space-between;
+  flex-direction: column;
+  // justify-content: flex-end;
+  align-items: baseline;
   padding-bottom: 6px;
 }
 
@@ -439,14 +447,14 @@ td.uk-background-muted {
     font-size: carbon--type-scale(2);
   }
 
-  &__raw-data-link {
-    right: 2rem;
-    top: 0.5rem;
-    color: $text-02;
-    &:hover {
-      color: $text-01;
-    }
-  }
+  // &__main-page-data-link {
+  //   right: 2rem;
+  //   top: 2rem;
+  //   color: $text-02;
+  //   &:hover {
+  //     color: $text-01;
+  //   }
+  // }
 
   &__os-list-item {
     white-space: pre;


### PR DESCRIPTION
As requested in GRD-94140, this PR changes:
1. remove the raw data link in the upper left screen
2. add page title "Guardium Supported Datasources"

![image](https://github.com/user-attachments/assets/700636fb-e82c-437d-b909-c503b8d16fce)
