### PR TITLE
GRD-94621, GRD-91786, GRD-94699:Fixes for 3 defects

### DIFF
--- a/consolidation-script2/data/input/OnPrem_ExStap.csv
+++ b/consolidation-script2/data/input/OnPrem_ExStap.csv
@@ -12,7 +12,7 @@ GDP,GDP 12.1,Sybase IQ,All versions,,,,,https://github.com/IBM/Guardium_External
 GDP,GDP 12.1,Redis,All versions,,,,,https://github.com/IBM/Guardium_External_S-TAP
 GDP,GDP 12.1,Netezza,All versions,,,,,https://github.com/IBM/Guardium_External_S-TAP
 GDP,GDP 12.1,MySQL,All versions,,,,,https://github.com/IBM/Guardium_External_S-TAP
-GDP,GDP 12.1,MemSQL,All versions,,,,,https://github.com/IBM/Guardium_External_S-TAP
+GDP,GDP 12.1,SingleStore(formerly MemSQL),All versions,,,,,https://github.com/IBM/Guardium_External_S-TAP
 GDP,GDP 12.1,Greenplum,All versions,,,,,https://github.com/IBM/Guardium_External_S-TAP
 GDP,GDP 12.1,MariaDB,All versions,,,,,https://github.com/IBM/Guardium_External_S-TAP
 GDP,GDP 12.1,IBM Db2,All versions,,,,,https://github.com/IBM/Guardium_External_S-TAP

--- a/consolidation-script2/data/input/OnPrem_Stap.csv
+++ b/consolidation-script2/data/input/OnPrem_Stap.csv
@@ -1082,97 +1082,97 @@ GDP,11.4,Red Hat,Red Hat 8,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,
 GDP,11.4,Red Hat,Red Hat 9,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,11.4,Suse,Suse 12  64bit,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
 GDP,11.4,Suse,Suse 15  64bit,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
-GDP,11.4,CentOS,CentOS 7x,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Red Hat,Red Hat 7,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.1,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.2,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.3,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.4,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.5,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.6,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.7,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.8,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.9,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 8,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 9,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,CentOS,CentOS 7x,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Red Hat,Red Hat 7,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.1,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.2,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.3,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.4,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.5,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.6,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.7,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.8,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.9,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 8,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 9,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,CentOS,CentOS 7x,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Red Hat,Red Hat 7,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.1,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.2,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.3,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.4,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.5,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.6,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.7,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.8,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.9,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 8,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 9,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,CentOS,CentOS 7x,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Red Hat,Red Hat 7,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.1,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.2,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.3,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.4,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.5,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.6,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.7,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.8,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.9,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 8,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 9,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,CentOS,CentOS 7x,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Red Hat,Red Hat 7,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.1,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.2,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.3,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.4,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.5,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.6,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.7,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.8,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.9,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 8,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 9,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,CentOS,CentOS 7x,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Red Hat,Red Hat 7,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.1,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.2,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.3,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.4,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.5,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.6,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.7,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.8,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.9,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 8,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 9,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,CentOS,CentOS 7x,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Red Hat,Red Hat 7,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.1,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.2,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.3,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.4,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.5,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.6,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.7,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.8,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.9,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 8,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 9,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,11.4,CentOS,CentOS 7x,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,ATAP with Linux 2.6.36 and higher only
 GDP,11.4,Red Hat,Red Hat 7,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.1,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -3588,97 +3588,97 @@ GDP,11.5,Red Hat,Red Hat 8,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,
 GDP,11.5,Red Hat,Red Hat 9,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,11.5,Suse,Suse 12 64bit,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
 GDP,11.5,Suse,Suse 15 64bit,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
-GDP,11.5,CentOS,CentOS 7x,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.5,Red Hat,Red Hat 7,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.1,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.2,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.3,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.4,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.5,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.6,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.7,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.8,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.9,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 8,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 9,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,CentOS,CentOS 7x,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.5,Red Hat,Red Hat 7,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.1,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.2,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.3,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.4,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.5,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.6,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.7,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.8,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.9,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 8,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 9,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,CentOS,CentOS 7x,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.5,Red Hat,Red Hat 7,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.1,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.2,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.3,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.4,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.5,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.6,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.7,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.8,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.9,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 8,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 9,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,CentOS,CentOS 7x,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.5,Red Hat,Red Hat 7,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.1,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.2,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.3,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.4,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.5,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.6,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.7,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.8,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.9,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 8,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 9,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,CentOS,CentOS 7x,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.5,Red Hat,Red Hat 7,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.1,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.2,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.3,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.4,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.5,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.6,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.7,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.8,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.9,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 8,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 9,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,CentOS,CentOS 7x,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.5,Red Hat,Red Hat 7,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.1,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.2,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.3,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.4,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.5,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.6,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.7,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.8,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.9,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 8,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 9,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,CentOS,CentOS 7x,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.5,Red Hat,Red Hat 7,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.1,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.2,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.3,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.4,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.5,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.6,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.7,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.8,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.9,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 8,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 9,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,11.5,CentOS,CentOS 7x,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,ATAP with Linux 2.6.36 and higher only
 GDP,11.5,Red Hat,Red Hat 7,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.5,Red Hat,Red Hat 7.1,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -6052,97 +6052,97 @@ GDP,12.0,Red Hat,Red Hat 8,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,
 GDP,12.0,Red Hat,Red Hat 9,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,12.0,Suse,Suse 12  64bit,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
 GDP,12.0,Suse,Suse 15  64bit,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
-GDP,12.0,CentOS,CentOS 7x,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.0,Red Hat,Red Hat 7,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.1,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.2,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.3,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.4,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.5,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.6,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.7,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.8,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.9,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 8,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 9,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,CentOS,CentOS 7x,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.0,Red Hat,Red Hat 7,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.1,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.2,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.3,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.4,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.5,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.6,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.7,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.8,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.9,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 8,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 9,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,CentOS,CentOS 7x,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.0,Red Hat,Red Hat 7,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.1,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.2,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.3,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.4,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.5,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.6,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.7,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.8,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.9,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 8,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 9,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,CentOS,CentOS 7x,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.0,Red Hat,Red Hat 7,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.1,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.2,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.3,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.4,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.5,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.6,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.7,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.8,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.9,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 8,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 9,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,CentOS,CentOS 7x,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.0,Red Hat,Red Hat 7,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.1,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.2,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.3,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.4,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.5,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.6,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.7,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.8,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.9,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 8,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 9,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,CentOS,CentOS 7x,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.0,Red Hat,Red Hat 7,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.1,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.2,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.3,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.4,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.5,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.6,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.7,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.8,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.9,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 8,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 9,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,CentOS,CentOS 7x,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.0,Red Hat,Red Hat 7,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.1,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.2,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.3,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.4,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.5,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.6,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.7,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.8,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.9,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 8,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 9,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,12.0,CentOS,CentOS 7x,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,ATAP with Linux 2.6.36 and higher only
 GDP,12.0,Red Hat,Red Hat 7,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,12.0,Red Hat,Red Hat 7.1,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -8577,97 +8577,97 @@ GDP,12.1,Red Hat,Red Hat 8,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,
 GDP,12.1,Red Hat,Red Hat 9,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,12.1,Suse,Suse 12  64bit,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
 GDP,12.1,Suse,Suse 15  64bit,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
-GDP,12.1,CentOS,CentOS 7x,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.1,Red Hat,Red Hat 7,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.1,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.2,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.3,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.4,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.5,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.6,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.7,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.8,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.9,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 8,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 9,MemSQL,MemSQL 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,CentOS,CentOS 7x,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.1,Red Hat,Red Hat 7,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.1,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.2,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.3,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.4,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.5,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.6,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.7,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.8,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.9,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 8,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 9,MemSQL,MemSQL 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,CentOS,CentOS 7x,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.1,Red Hat,Red Hat 7,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.1,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.2,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.3,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.4,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.5,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.6,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.7,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.8,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.9,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 8,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 9,MemSQL,MemSQL 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,CentOS,CentOS 7x,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.1,Red Hat,Red Hat 7,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.1,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.2,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.3,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.4,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.5,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.6,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.7,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.8,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.9,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 8,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 9,MemSQL,MemSQL 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,CentOS,CentOS 7x,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.1,Red Hat,Red Hat 7,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.1,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.2,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.3,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.4,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.5,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.6,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.7,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.8,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.9,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 8,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 9,MemSQL,MemSQL 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,CentOS,CentOS 7x,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.1,Red Hat,Red Hat 7,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.1,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.2,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.3,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.4,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.5,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.6,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.7,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.8,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.9,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 8,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 9,MemSQL,MemSQL 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,CentOS,CentOS 7x,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.1,Red Hat,Red Hat 7,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.1,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.2,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.3,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.4,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.5,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.6,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.7,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.8,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.9,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 8,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 9,MemSQL,MemSQL 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,12.1,CentOS,CentOS 7x,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,ATAP with Linux 2.6.36 and higher only
 GDP,12.1,Red Hat,Red Hat 7,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,12.1,Red Hat,Red Hat 7.1,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.

--- a/consolidation-script2/data/input/OnPrem_Stap.csv
+++ b/consolidation-script2/data/input/OnPrem_Stap.csv
@@ -287,8 +287,8 @@ GDP,11.4,Red Hat,Red Hat 7.8,Couchbase,Couchbase 7.1,Double proxy setting,Double
 GDP,11.4,Red Hat,Red Hat 7.9,Couchbase,Couchbase 7.1,Double proxy setting,Double proxy setting,Double proxy setting,,,Double proxy setting,NA,,,,,,"Couchbase does not transmit the ""DB user"" in TCP communications, so Guardium cannot capture it by using double proxy configuration."
 GDP,11.4,Red Hat,Red Hat 8,Couchbase,Couchbase 7.1,Double proxy setting,Double proxy setting,Double proxy setting,,,Double proxy setting,NA,,,,,,"Couchbase does not transmit the ""DB user"" in TCP communications, so Guardium cannot capture it by using double proxy configuration."
 GDP,11.4,Red Hat,Red Hat 9,Couchbase,Couchbase 7.1,Double proxy setting,Double proxy setting,Double proxy setting,,,Double proxy setting,NA,,,,,,"Couchbase does not transmit the ""DB user"" in TCP communications, so Guardium cannot capture it by using double proxy configuration."
-GDP,11.4,z/OS,z/OS 2.3,Datasets for z/OS,Datasets for z/OS 2.3,NA,Yes,NA,Yes,,No,No,No,,,,,
-GDP,11.4,z/OS,z/OS 2.4,Datasets for z/OS,Datasets for z/OS 2.3,NA,Yes,NA,Yes,,No,No,No,,,,,
+GDP,11.4,z/OS,z/OS 2.3,IBM Data Sets for z/OS,IBM Data Sets for z/OS 2.3,NA,Yes,NA,Yes,,No,No,No,,,,,
+GDP,11.4,z/OS,z/OS 2.4,IBM Data Sets for z/OS,IBM Data Sets for z/OS 2.3,NA,Yes,NA,Yes,,No,No,No,,,,,
 GDP,11.4,AIX,AIX 7.2,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
 GDP,11.4,CentOS,CentOS 7x,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Debian,Debian 11,IBM Db2,IBM Db2 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
@@ -1082,97 +1082,97 @@ GDP,11.4,Red Hat,Red Hat 8,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,
 GDP,11.4,Red Hat,Red Hat 9,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,11.4,Suse,Suse 12  64bit,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
 GDP,11.4,Suse,Suse 15  64bit,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
-GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,CentOS,CentOS 7x,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.4,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,11.4,CentOS,CentOS 7x,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,ATAP with Linux 2.6.36 and higher only
 GDP,11.4,Red Hat,Red Hat 7,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.1,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -2813,8 +2813,8 @@ GDP,11.5,Red Hat,Red Hat 7.8,Couchbase,Couchbase 7.1,Double proxy setting,Double
 GDP,11.5,Red Hat,Red Hat 7.9,Couchbase,Couchbase 7.1,Double proxy setting,Double proxy setting,Double proxy setting,,,Double proxy setting,NA,,,,,,"Couchbase does not transmit the ""DB user"" in TCP communications, so Guardium cannot capture it by using double proxy configuration."
 GDP,11.5,Red Hat,Red Hat 8,Couchbase,Couchbase 7.1,Double proxy setting,Double proxy setting,Double proxy setting,,,Double proxy setting,NA,,,,,,"Couchbase does not transmit the ""DB user"" in TCP communications, so Guardium cannot capture it by using double proxy configuration."
 GDP,11.5,Red Hat,Red Hat 9,Couchbase,Couchbase 7.1,Double proxy setting,Double proxy setting,Double proxy setting,,,Double proxy setting,NA,,,,,,"Couchbase does not transmit the ""DB user"" in TCP communications, so Guardium cannot capture it by using double proxy configuration."
-GDP,11.5,z/OS,z/OS 2.3,Datasets for z/OS,Datasets for z/OS 2.3,NA,Yes,NA,Yes,,No,No,No,,,,,
-GDP,11.5,z/OS,z/OS 2.4,Datasets for z/OS,Datasets for z/OS 2.3,NA,Yes,NA,Yes,,No,No,No,,,,,
+GDP,11.5,z/OS,z/OS 2.3,IBM Data Sets for z/OS,IBM Data Sets for z/OS 2.3,NA,Yes,NA,Yes,,No,No,No,,,,,
+GDP,11.5,z/OS,z/OS 2.4,IBM Data Sets for z/OS,IBM Data Sets for z/OS 2.3,NA,Yes,NA,Yes,,No,No,No,,,,,
 GDP,11.5,AIX,AIX 7.2,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
 GDP,11.5,AIX,AIX 7.3,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
 GDP,11.5,CentOS,CentOS 7x,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,ATAP with Linux 2.6.36 and higher only.
@@ -3588,97 +3588,97 @@ GDP,11.5,Red Hat,Red Hat 8,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,
 GDP,11.5,Red Hat,Red Hat 9,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,11.5,Suse,Suse 12 64bit,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
 GDP,11.5,Suse,Suse 15 64bit,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
-GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,CentOS,CentOS 7x,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.5,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,11.5,CentOS,CentOS 7x,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,ATAP with Linux 2.6.36 and higher only
 GDP,11.5,Red Hat,Red Hat 7,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.5,Red Hat,Red Hat 7.1,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -5288,8 +5288,8 @@ GDP,12.0,Red Hat,Red Hat 7.8,Couchbase,Couchbase 7.1,Double proxy setting,Double
 GDP,12.0,Red Hat,Red Hat 7.9,Couchbase,Couchbase 7.1,Double proxy setting,Double proxy setting,Double proxy setting,,,Double proxy setting,NA,,,,,,"Couchbase does not transmit the ""DB user"" in TCP communications, so Guardium cannot capture it by using double proxy configuration."
 GDP,12.0,Red Hat,Red Hat 8,Couchbase,Couchbase 7.1,Double proxy setting,Double proxy setting,Double proxy setting,,,Double proxy setting,NA,,,,,,"Couchbase does not transmit the ""DB user"" in TCP communications, so Guardium cannot capture it by using double proxy configuration."
 GDP,12.0,Red Hat,Red Hat 9,Couchbase,Couchbase 7.1,Double proxy setting,Double proxy setting,Double proxy setting,,,Double proxy setting,NA,,,,,,"Couchbase does not transmit the ""DB user"" in TCP communications, so Guardium cannot capture it by using double proxy configuration."
-GDP,12.0,z/OS,z/OS 2.3,Datasets for z/OS,Datasets for z/OS 2.3,NA,Yes,NA,Yes,,No,No,No,,,,,
-GDP,12.0,z/OS,z/OS 2.4,Datasets for z/OS,Datasets for z/OS 2.3,NA,Yes,NA,Yes,,No,No,No,,,,,
+GDP,12.0,z/OS,z/OS 2.3,IBM Data Sets for z/OS,IBM Data Sets for z/OS 2.3,NA,Yes,NA,Yes,,No,No,No,,,,,
+GDP,12.0,z/OS,z/OS 2.4,IBM Data Sets for z/OS,IBM Data Sets for z/OS 2.3,NA,Yes,NA,Yes,,No,No,No,,,,,
 GDP,12.0,AIX,AIX 7.2,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
 GDP,12.0,AIX,AIX 7.3,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
 GDP,12.0,CentOS,CentOS 7x,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,ATAP with Linux 2.6.36 and higher only.
@@ -6052,97 +6052,97 @@ GDP,12.0,Red Hat,Red Hat 8,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,
 GDP,12.0,Red Hat,Red Hat 9,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,12.0,Suse,Suse 12  64bit,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
 GDP,12.0,Suse,Suse 15  64bit,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
-GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,CentOS,CentOS 7x,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.0,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,12.0,CentOS,CentOS 7x,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,ATAP with Linux 2.6.36 and higher only
 GDP,12.0,Red Hat,Red Hat 7,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,12.0,Red Hat,Red Hat 7.1,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -7807,8 +7807,8 @@ GDP,12.1,Red Hat,Red Hat 7.8,Couchbase,Couchbase 7.1,Double proxy setting,Double
 GDP,12.1,Red Hat,Red Hat 7.9,Couchbase,Couchbase 7.1,Double proxy setting,Double proxy setting,Double proxy setting,,,Double proxy setting,NA,,,,,,"Couchbase does not transmit the ""DB user"" in TCP communications, so Guardium cannot capture it by using double proxy configuration."
 GDP,12.1,Red Hat,Red Hat 8,Couchbase,Couchbase 7.1,Double proxy setting,Double proxy setting,Double proxy setting,,,Double proxy setting,NA,,,,,,"Couchbase does not transmit the ""DB user"" in TCP communications, so Guardium cannot capture it by using double proxy configuration."
 GDP,12.1,Red Hat,Red Hat 9,Couchbase,Couchbase 7.1,Double proxy setting,Double proxy setting,Double proxy setting,,,Double proxy setting,NA,,,,,,"Couchbase does not transmit the ""DB user"" in TCP communications, so Guardium cannot capture it by using double proxy configuration."
-GDP,12.1,z/OS,z/OS 2.3,Datasets for z/OS,Datasets for z/OS 2.3,NA,Yes,NA,Yes,,No,No,No,,,,,
-GDP,12.1,z/OS,z/OS 2.4,Datasets for z/OS,Datasets for z/OS 2.3,NA,Yes,NA,Yes,,No,No,No,,,,,
+GDP,12.1,z/OS,z/OS 2.3,IBM Data Sets for z/OS,IBM Data Sets for z/OS 2.3,NA,Yes,NA,Yes,,No,No,No,,,,,
+GDP,12.1,z/OS,z/OS 2.4,IBM Data Sets for z/OS,IBM Data Sets for z/OS 2.3,NA,Yes,NA,Yes,,No,No,No,,,,,
 GDP,12.1,AIX,AIX 7.2,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
 GDP,12.1,AIX,AIX 7.3,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
 GDP,12.1,CentOS,CentOS 7x,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,ATAP with Linux 2.6.36 and higher only.
@@ -8577,97 +8577,97 @@ GDP,12.1,Red Hat,Red Hat 8,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,
 GDP,12.1,Red Hat,Red Hat 9,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,12.1,Suse,Suse 12  64bit,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
 GDP,12.1,Suse,Suse 15  64bit,MariaDB,MariaDB 5.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
-GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
-GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),SingleStore(formerly MemSQL) 7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),5.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),6.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),6.5,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),6.7,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),6.8,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),7.0,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,CentOS,CentOS 7x,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.1,Red Hat,Red Hat 7,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.1,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.2,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.3,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.4,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.5,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.6,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.7,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.8,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.9,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 8,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 9,SingleStore(formerly MemSQL),7.1,KTAP,KTAP,KTAP,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,12.1,CentOS,CentOS 7x,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,ATAP with Linux 2.6.36 and higher only
 GDP,12.1,Red Hat,Red Hat 7,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,12.1,Red Hat,Red Hat 7.1,MongoDB,MongoDB 3.2,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.

--- a/consolidation-script2/data/input/OnPrem_Stap.csv
+++ b/consolidation-script2/data/input/OnPrem_Stap.csv
@@ -11463,7 +11463,6 @@ GDP,12.1,Red Hat,Red Hat 7.8,Neo4j,Neo4j 5.4,Double proxy setting,Double proxy s
 GDP,12.1,Red Hat,Red Hat 7.9,Neo4j,Neo4j 5.4,Double proxy setting,Double proxy setting,Double Proxy setting,,,Yes,NA,,,,,,
 GDP,12.1,Red Hat,Red Hat 8,Neo4j,Neo4j 5.4,Double proxy setting,Double proxy setting,Double Proxy setting,,,Yes,NA,,,,,,
 GDP,12.1,Red Hat,Red Hat 9,Neo4j,Neo4j 5.4,Double proxy setting,Double proxy setting,Double Proxy setting,,,Yes,NA,,,,,,
-GDP,12.1,Red Hat,Ubuntu 20.04,MariaDB,MariaDB 11.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,11.5,Red Hat,Red Hat 7,Vertica,Vertica 23.3,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP",,,KTAP,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,11.5,Red Hat,Red Hat 7.1,Vertica,Vertica 23.3,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP",,,KTAP,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,11.5,Red Hat,Red Hat 7.2,Vertica,Vertica 23.3,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP",,,KTAP,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE


### PR DESCRIPTION
This PR contains fix for 
GRD-94621: Rename MemSQL to SingleStore
GRD-91786: Update name "Datasets for z/OS" to "IBM Data Sets for z/OS"
GRD-94699: Remove incorrect entry of data for MariaDB, Red Hat .* Ubuntu