### PR TITLE
GRD-93602: Removed deprecated platforms for STAP

### DIFF
--- a/consolidation-script2/data/input/OnPrem_Stap.csv
+++ b/consolidation-script2/data/input/OnPrem_Stap.csv
@@ -291,7 +291,6 @@ GDP,11.4,z/OS,z/OS 2.3,IBM Data Sets for z/OS,IBM Data Sets for z/OS 2.3,NA,Yes,
 GDP,11.4,z/OS,z/OS 2.4,IBM Data Sets for z/OS,IBM Data Sets for z/OS 2.3,NA,Yes,NA,Yes,,No,No,No,,,,,
 GDP,11.4,AIX,AIX 7.2,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
 GDP,11.4,CentOS,CentOS 7x,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 11,IBM Db2,IBM Db2 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
 GDP,11.4,HPUX,HPUX 11.23 PARISC 11.23 IA64,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
 GDP,11.4,HPUX,HPUX 11.31 PARISC 11.31 IA64,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
 GDP,11.4,Red Hat,Red Hat 7,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP ATAP with Linux 2.6.36 and higher only
@@ -313,7 +312,6 @@ GDP,11.4,Solaris,Solaris 11.4,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, K
 GDP,11.4,Suse,Suse 12  64bit,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Suse,Suse 15  64bit,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Zlinux,Zlinux Red Hat 6,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP ATAP with Linux 2.6.36 and higher only
 GDP,11.4,Zlinux,Zlinux Red Hat 7,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP ATAP with Linux 2.6.36 and higher only
 GDP,11.4,Zlinux,Zlinux Red Hat 7.1,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP ATAP with Linux 2.6.36 and higher only
 GDP,11.4,Zlinux,Zlinux Red Hat 7.2,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP ATAP with Linux 2.6.36 and higher only
@@ -325,13 +323,11 @@ GDP,11.4,Zlinux,Zlinux Red Hat 7.7,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Ex
 GDP,11.4,Zlinux,Zlinux Red Hat 7.8,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP ATAP with Linux 2.6.36 and higher only
 GDP,11.4,Zlinux,Zlinux Red Hat 7.9,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP ATAP with Linux 2.6.36 and higher only
 GDP,11.4,Zlinux,Zlinux Red Hat 8,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP ATAP with Linux 2.6.36 and higher only
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 12  64bit,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 15  64bit,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Ubuntu 18.0,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
 GDP,11.4,AIX,AIX 7.2,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
 GDP,11.4,CentOS,CentOS 7x,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 11,IBM Db2,IBM Db2 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
 GDP,11.4,HPUX,HPUX 11.23 PARISC 11.23 IA64,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
 GDP,11.4,HPUX,HPUX 11.31 PARISC 11.31 IA64,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
 GDP,11.4,Red Hat,Red Hat 7,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -353,7 +349,6 @@ GDP,11.4,Solaris,Solaris 11.4,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP",KTAP,Db2 Exi
 GDP,11.4,Suse,Suse 12  64bit,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Suse,Suse 15  64bit,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Zlinux,Zlinux Red Hat 6,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.1,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.2,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -365,13 +360,11 @@ GDP,11.4,Zlinux,Zlinux Red Hat 7.7,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Ex
 GDP,11.4,Zlinux,Zlinux Red Hat 7.8,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.9,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 8,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 12  64bit,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 15  64bit,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Ubuntu 18.0,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
 GDP,11.4,AIX,AIX 7.2,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,
 GDP,11.4,CentOS,CentOS 7x,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 11,IBM Db2,IBM Db2 11.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
 GDP,11.4,HPUX,HPUX 11.23 PARISC 11.23 IA64,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP",KTAP,Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,
 GDP,11.4,HPUX,HPUX 11.31 PARISC 11.31 IA64,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP",KTAP,Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,
 GDP,11.4,Red Hat,Red Hat 7,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -393,7 +386,6 @@ GDP,11.4,Solaris,Solaris 11.4,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, K
 GDP,11.4,Suse,Suse 12  64bit,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Suse,Suse 15  64bit,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Zlinux,Zlinux Red Hat 6,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.1,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.2,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -405,13 +397,11 @@ GDP,11.4,Zlinux,Zlinux Red Hat 7.7,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Ex
 GDP,11.4,Zlinux,Zlinux Red Hat 7.8,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.9,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 8,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 12  64bit,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 15  64bit,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Ubuntu 18.0,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
 GDP,11.4,AIX,AIX 7.2,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,
 GDP,11.4,CentOS,CentOS 7x,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 11,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
 GDP,11.4,HPUX,HPUX 11.23 PARISC 11.23 IA64,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,
 GDP,11.4,HPUX,HPUX 11.31 PARISC 11.31 IA64,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,
 GDP,11.4,Red Hat,Red Hat 7,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -433,7 +423,6 @@ GDP,11.4,Solaris,Solaris 11.4,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, K
 GDP,11.4,Suse,Suse 12  64bit,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Suse,Suse 15  64bit,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Zlinux,Zlinux Red Hat 6,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.1,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.2,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -445,13 +434,11 @@ GDP,11.4,Zlinux,Zlinux Red Hat 7.7,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Ex
 GDP,11.4,Zlinux,Zlinux Red Hat 7.8,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.9,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 8,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 12  64bit,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 15  64bit,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Ubuntu 18.0,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
 GDP,11.4,AIX,AIX 7.2,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
 GDP,11.4,CentOS,CentOS 7x,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 11,IBM Db2,IBM Db2 9.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
 GDP,11.4,HPUX,HPUX 11.23 PARISC 11.23 IA64,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
 GDP,11.4,HPUX,HPUX 11.31 PARISC 11.31 IA64,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
 GDP,11.4,Red Hat,Red Hat 7,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -473,7 +460,6 @@ GDP,11.4,Solaris,Solaris 11.4,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP",KTAP,Db2 Exit
 GDP,11.4,Suse,Suse 12  64bit,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Suse,Suse 15  64bit,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Zlinux,Zlinux Red Hat 6,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.1,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.2,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -485,13 +471,11 @@ GDP,11.4,Zlinux,Zlinux Red Hat 7.7,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exi
 GDP,11.4,Zlinux,Zlinux Red Hat 7.8,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.9,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 8,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 12  64bit,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 15  64bit,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Ubuntu 18.0,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
 GDP,11.4,AIX,AIX 7.2,IBM Db2 pureScale,IBM Db2 pureScale 10.1,"Db2 Exit, KTAP",KTAP,Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,CentOS,CentOS 7x,IBM Db2 pureScale,IBM Db2 pureScale 10.1,"Db2 Exit, KTAP",KTAP,Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 11,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,HPUX,HPUX 11.23 PARISC 11.23 IA64,IBM Db2 pureScale,IBM Db2 pureScale 10.1,"Db2 Exit, KTAP",KTAP,Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,HPUX,HPUX 11.31 PARISC 11.31 IA64,IBM Db2 pureScale,IBM Db2 pureScale 10.1,"Db2 Exit, KTAP",KTAP,Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,Red Hat,Red Hat 7,IBM Db2 pureScale,IBM Db2 pureScale 10.1,"Db2 Exit, KTAP","Teradata Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,SSL Encryption supported only using Db2 EXIT. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -510,7 +494,6 @@ GDP,11.4,Solaris,Solaris 10,IBM Db2 pureScale,IBM Db2 pureScale 10.1,"Db2 Exit, 
 GDP,11.4,Ubuntu,Ubuntu 16.04,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,AIX,AIX 7.2,IBM Db2 pureScale,IBM Db2 pureScale 10.5,"Db2 Exit, KTAP","Teradata Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,CentOS,CentOS 7x,IBM Db2 pureScale,IBM Db2 pureScale 10.5,"Db2 Exit, KTAP",,Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 11,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,HPUX,HPUX 11.23 PARISC 11.23 IA64,IBM Db2 pureScale,IBM Db2 pureScale 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,HPUX,HPUX 11.31 PARISC 11.31 IA64,IBM Db2 pureScale,IBM Db2 pureScale 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,HPUX,HPUX 11.31 PARISC 11.31 IA64,IBM Db2 pureScale,IBM Db2 pureScale 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SSL Encryption supported only using Db2 EXIT
@@ -532,7 +515,6 @@ GDP,11.4,Solaris,Solaris 10,IBM Db2 pureScale,IBM Db2 pureScale 10.5,"Db2 Exit, 
 GDP,11.4,Ubuntu,Ubuntu 16.04,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,AIX,AIX 7.2,IBM Db2 pureScale,IBM Db2 pureScale 11,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,CentOS,CentOS 7x,IBM Db2 pureScale,IBM Db2 pureScale 11,"Db2 Exit, KTAP",,Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 11,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,HPUX,HPUX 11.23 PARISC 11.23 IA64,IBM Db2 pureScale,IBM Db2 pureScale 11,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,HPUX,HPUX 11.31 PARISC 11.31 IA64,IBM Db2 pureScale,IBM Db2 pureScale 11,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,HPUX,HPUX 11.31 PARISC 11.31 IA64,IBM Db2 pureScale,IBM Db2 pureScale 11,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SSL Encryption supported only using Db2 EXIT
@@ -554,7 +536,6 @@ GDP,11.4,Solaris,Solaris 10,IBM Db2 pureScale,IBM Db2 pureScale 11,"Db2 Exit, KT
 GDP,11.4,Ubuntu,Ubuntu 16.04,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,AIX,AIX 7.2,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,
 GDP,11.4,CentOS,CentOS 7x,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 11,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
 GDP,11.4,HPUX,HPUX 11.23 PARISC 11.23 IA64,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,
 GDP,11.4,HPUX,HPUX 11.31 PARISC 11.31 IA64,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,
 GDP,11.4,HPUX,HPUX 11.31 PARISC 11.31 IA64,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,
@@ -578,7 +559,6 @@ GDP,11.4,Solaris,Solaris 11.4,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit
 GDP,11.4,Suse,Suse 12  64bit,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Suse,Suse 15  64bit,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Zlinux,Zlinux Red Hat 6,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.1,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.2,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -590,7 +570,6 @@ GDP,11.4,Zlinux,Zlinux Red Hat 7.7,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2
 GDP,11.4,Zlinux,Zlinux Red Hat 7.8,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.9,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 8,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 12  64bit,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 15  64bit,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Ubuntu 18.0,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
@@ -614,7 +593,6 @@ GDP,11.4,Red Hat,Red Hat 8,IBM Db2 pureScale,IBM Db2 pureScale 9.7,"Db2 Exit, KT
 GDP,11.4,Red Hat,Red Hat 9,IBM Db2 pureScale,IBM Db2 pureScale 9.7,"Db2 Exit, KTAP",,Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,SSL Encryption supported only using Db2 EXIT. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,AIX,AIX 7.2,IBM Db2 pureScale,IBM Db2 pureScale 9.8,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,CentOS,CentOS 7x,IBM Db2 pureScale,IBM Db2 pureScale 9.8,"Db2 Exit, KTAP",,Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 11,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,Solaris,Solaris 10,IBM Db2 pureScale,IBM Db2 pureScale 9.8,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,Ubuntu,Ubuntu 16.04,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,Red Hat,Red Hat 7,Elasticsearch,Elasticsearch 7.3,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
@@ -822,7 +800,6 @@ GDP,11.4,z/OS,z/OS 2.3,IBM IMS,IBM IMS 15,All traffic to IMS is considered local
 GDP,11.4,z/OS,z/OS 2.4,IBM IMS,IBM IMS 15,All traffic to IMS is considered local.,Yes,NA,Yes,,Yes,,NA,,,,,
 GDP,11.4,AIX,AIX 7.2,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,KTAP,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
 GDP,11.4,CentOS,CentOS 7x,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 11,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,11.4,HPUX,HPUX 11.23 PARISC 11.23 IA64,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,KTAP,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
 GDP,11.4,HPUX,HPUX 11.31 PARISC 11.31 IA64,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,KTAP,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
 GDP,11.4,HPUX,HPUX 11.31 PARISC 11.31 IA64,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,KTAP,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
@@ -847,7 +824,6 @@ GDP,11.4,Solaris,Solaris 11.4,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,KTAP,,KT
 GDP,11.4,Suse,Suse 12  64bit,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Suse,Suse 15  64bit,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Zlinux,Zlinux Red Hat 6,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.1,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.2,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -859,13 +835,11 @@ GDP,11.4,Zlinux,Zlinux Red Hat 7.7,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATA
 GDP,11.4,Zlinux,Zlinux Red Hat 7.8,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.9,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 8,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 12  64bit,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 15  64bit,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Ubuntu 18.0,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,11.4,AIX,AIX 7.2,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, KTAP",,"Informix Exit, KTAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher
 GDP,11.4,CentOS,CentOS 7x,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
-GDP,11.4,Debian,Debian 11,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,HPUX,HPUX 11.23 PARISC 11.23 IA64,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, KTAP",,"Informix Exit, KTAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher
 GDP,11.4,HPUX,HPUX 11.31 PARISC 11.31 IA64,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, KTAP",,"Informix Exit, KTAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher
 GDP,11.4,HPUX,HPUX 11.31 PARISC 11.31 IA64,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, KTAP",,"Informix Exit, KTAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher
@@ -890,7 +864,6 @@ GDP,11.4,Solaris,Solaris 11.4,IBM Informix,IBM Informix 12.1,"Informix Exit, KTA
 GDP,11.4,Suse,Suse 12  64bit,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Suse,Suse 15  64bit,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Red Hat 6,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.1,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.2,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -902,13 +875,11 @@ GDP,11.4,Zlinux,Zlinux Red Hat 7.7,IBM Informix,IBM Informix 12.1,"Informix Exit
 GDP,11.4,Zlinux,Zlinux Red Hat 7.8,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.9,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 8,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 12  64bit,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 15  64bit,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Ubuntu 18.0,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,AIX,AIX 7.2,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, KTAP",,"Informix Exit, KTAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher
 GDP,11.4,CentOS,CentOS 7x,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP ","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
-GDP,11.4,Debian,Debian 11,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,HPUX,HPUX 11.23 PARISC 11.23 IA64,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, KTAP",,"Informix Exit, KTAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher
 GDP,11.4,HPUX,HPUX 11.31 PARISC 11.31 IA64,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, KTAP",,"Informix Exit, KTAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher
 GDP,11.4,HPUX,HPUX 11.31 PARISC 11.31 IA64,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, KTAP",,"Informix Exit, KTAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher
@@ -933,7 +904,6 @@ GDP,11.4,Solaris,Solaris 11.4,IBM Informix,IBM Informix 14.1,"Informix Exit, KTA
 GDP,11.4,Suse,Suse 12  64bit,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Suse,Suse 15  64bit,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Red Hat 6,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.1,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.2,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -945,7 +915,6 @@ GDP,11.4,Zlinux,Zlinux Red Hat 7.7,IBM Informix,IBM Informix 14.1,"Informix Exit
 GDP,11.4,Zlinux,Zlinux Red Hat 7.8,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.9,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 8,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 12  64bit,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 15  64bit,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Ubuntu 18.04,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
@@ -1324,7 +1293,6 @@ GDP,11.4,Red Hat,Red Hat 9,MongoDB,MongoDB 7.0,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP"
 GDP,11.4,Suse,Suse 12  64bit,MongoDB,MongoDB 7.0,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Suse,Suse 15  64bit,MongoDB,MongoDB 7.0,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,CentOS,CentOS 7x,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 11,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
 GDP,11.4,Red Hat,Red Hat 7,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,11.4,Red Hat,Red Hat 7.1,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,11.4,Red Hat,Red Hat 7.2,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
@@ -1340,7 +1308,6 @@ GDP,11.4,Red Hat,Red Hat 9,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes
 GDP,11.4,Suse,Suse 12  64bit,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only
 GDP,11.4,Suse,Suse 15  64bit,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only
 GDP,11.4,CentOS,CentOS 7x,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 11,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
 GDP,11.4,Red Hat,Red Hat 7,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,11.4,Red Hat,Red Hat 7.1,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
 GDP,11.4,Red Hat,Red Hat 7.2,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
@@ -1479,7 +1446,6 @@ GDP,11.4,Solaris,Solaris 11.3,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,,"KTAP
 GDP,11.4,Solaris,Solaris 11.4,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,With V11.0 Stap. Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic Oracle Express XE is not supported
 GDP,11.4,Suse,Suse 12  64bit,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Suse,Suse 15  64bit,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Red Hat 6,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.1,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.2,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
@@ -1491,7 +1457,6 @@ GDP,11.4,Zlinux,Zlinux Red Hat 7.7,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,K
 GDP,11.4,Zlinux,Zlinux Red Hat 7.8,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.9,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 8,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 12  64bit,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 15  64bit,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,AIX,AIX 7.2,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic Oracle Express XE is not supported
@@ -1519,7 +1484,6 @@ GDP,11.4,Solaris,Solaris 11.3,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,,"KTAP,
 GDP,11.4,Solaris,Solaris 11.4,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,With V11.0 Stap. Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic Oracle Express XE is not supported
 GDP,11.4,Suse,Suse 12  64bit,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Suse,Suse 15  64bit,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Red Hat 6,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.1,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.2,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
@@ -1531,7 +1495,6 @@ GDP,11.4,Zlinux,Zlinux Red Hat 7.7,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KT
 GDP,11.4,Zlinux,Zlinux Red Hat 7.8,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.9,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 8,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 12  64bit,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 15  64bit,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,AIX,AIX 7.2,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic Oracle Express XE is not supported
@@ -1559,7 +1522,6 @@ GDP,11.4,Solaris,Solaris 11.3,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,,"KTAP,
 GDP,11.4,Solaris,Solaris 11.4,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,With V11.0 Stap. Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic Oracle Express XE is not supported
 GDP,11.4,Suse,Suse 12  64bit,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Suse,Suse 15  64bit,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Red Hat 6,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.1,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.2,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
@@ -1571,7 +1533,6 @@ GDP,11.4,Zlinux,Zlinux Red Hat 7.7,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KT
 GDP,11.4,Zlinux,Zlinux Red Hat 7.8,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.9,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 8,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 12  64bit,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 15  64bit,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,AIX,AIX 7.2,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic Oracle Express XE is not supported
@@ -1599,7 +1560,6 @@ GDP,11.4,Solaris,Solaris 11.3,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, 
 GDP,11.4,Solaris,Solaris 11.4,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,With V11.0 Stap. Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic Oracle Express XE is not supported
 GDP,11.4,Suse,Suse 12  64bit,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Suse,Suse 15  64bit,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Red Hat 6,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.1,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.2,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
@@ -1611,7 +1571,6 @@ GDP,11.4,Zlinux,Zlinux Red Hat 7.7,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTA
 GDP,11.4,Zlinux,Zlinux Red Hat 7.8,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.9,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 8,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 12  64bit,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 15  64bit,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,AIX,AIX 7.2,Oracle,Oracle 19c,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic Oracle Express XE is not supported
@@ -1650,7 +1609,6 @@ GDP,11.4,Zlinux,Zlinux Red Hat 7.7,Oracle,Oracle 19c,KTAP,KTAP,ATAP ASO SSL,,KTA
 GDP,11.4,Zlinux,Zlinux Red Hat 7.8,Oracle,Oracle 19c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.9,Oracle,Oracle 19c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 8,Oracle,Oracle 19c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 19c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 12  64bit,Oracle,Oracle 19c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 15  64bit,Oracle,Oracle 19c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,AIX,AIX 7.2,Oracle,Oracle 21c,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic Oracle Express XE is not supported
@@ -1688,7 +1646,6 @@ GDP,11.4,Zlinux,Zlinux Red Hat 7.7,Oracle,Oracle 21c,KTAP,KTAP,ATAP ASO SSL,,KTA
 GDP,11.4,Zlinux,Zlinux Red Hat 7.8,Oracle,Oracle 21c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 7.9,Oracle,Oracle 21c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Red Hat 8,Oracle,Oracle 21c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 21c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 12  64bit,Oracle,Oracle 21c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Zlinux,Zlinux Suse 15  64bit,Oracle,Oracle 21c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,CentOS,CentOS 7x,Oracle Exadata,Oracle Exadata 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,ATAP with Linux 2.6.36 and higher only
@@ -1871,7 +1828,6 @@ GDP,11.4,Solaris,Solaris 11.4,Oracle RAC,Oracle RAC 19c,KTAP,KTAP,ATAP ASO SSL,,
 GDP,11.4,Suse,Suse 12  64bit,Oracle RAC,Oracle RAC 19c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Suse,Suse 15  64bit,Oracle RAC,Oracle RAC 19c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,SLES 12 PPC64LE Little Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,CentOS,CentOS 7x,PostgreSQL,PostgreSQL 10,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
-GDP,11.4,Debian,Debian 11,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,Red Hat,Red Hat 7,PostgreSQL,PostgreSQL 10,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.1,PostgreSQL,PostgreSQL 10,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.2,PostgreSQL,PostgreSQL 10,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -1892,7 +1848,6 @@ GDP,11.4,Suse,Suse 12  64bit,PostgreSQL,PostgreSQL 10,KTAP,KTAP,ATAP,,,"KTAP, AT
 GDP,11.4,Suse,Suse 15  64bit,PostgreSQL,PostgreSQL 10,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,CentOS,CentOS 7x,PostgreSQL,PostgreSQL 11,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
-GDP,11.4,Debian,Debian 11,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,Red Hat,Red Hat 7,PostgreSQL,PostgreSQL 11,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.1,PostgreSQL,PostgreSQL 11,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.2,PostgreSQL,PostgreSQL 11,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -1913,7 +1868,6 @@ GDP,11.4,Suse,Suse 12  64bit,PostgreSQL,PostgreSQL 11,KTAP,KTAP,ATAP,,,"KTAP, AT
 GDP,11.4,Suse,Suse 15  64bit,PostgreSQL,PostgreSQL 11,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,CentOS,CentOS 7x,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
-GDP,11.4,Debian,Debian 11,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,Red Hat,Red Hat 7,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.1,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.2,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -1934,7 +1888,6 @@ GDP,11.4,Suse,Suse 12  64bit,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,ATAP,,,"KTAP, 
 GDP,11.4,Suse,Suse 15  64bit,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,CentOS,CentOS 7x,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
-GDP,11.4,Debian,Debian 11,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,Red Hat,Red Hat 7,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.1,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.2,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -1955,7 +1908,6 @@ GDP,11.4,Suse,Suse 12  64bit,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,ATAP,,,"KTAP, 
 GDP,11.4,Suse,Suse 15  64bit,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,CentOS,CentOS 7x,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
-GDP,11.4,Debian,Debian 11,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,Red Hat,Red Hat 7,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.1,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.2,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -1975,7 +1927,6 @@ GDP,11.4,Suse,Suse 12  64bit,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,ATAP,,,"KTAP, 
 GDP,11.4,Suse,Suse 15  64bit,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,CentOS,CentOS 7x,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
-GDP,11.4,Debian,Debian 11,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,Red Hat,Red Hat 7,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.1,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.2,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -1995,7 +1946,6 @@ GDP,11.4,Suse,Suse 12  64bit,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,ATAP,,,"KTAP, 
 GDP,11.4,Suse,Suse 15  64bit,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,CentOS,CentOS 7x,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
-GDP,11.4,Debian,Debian 11,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,Red Hat,Red Hat 7,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.1,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.2,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -2015,7 +1965,6 @@ GDP,11.4,Suse,Suse 12  64bit,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,ATAP,,,"KTAP, 
 GDP,11.4,Suse,Suse 15  64bit,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,CentOS,CentOS 7x,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
-GDP,11.4,Debian,Debian 11,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,Red Hat,Red Hat 7,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.1,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.2,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -2035,7 +1984,6 @@ GDP,11.4,Suse,Suse 12  64bit,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,ATAP,,,"KTAP, 
 GDP,11.4,Suse,Suse 15  64bit,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,CentOS,CentOS 7x,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
-GDP,11.4,Debian,Debian 11,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,Red Hat,Red Hat 7,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.1,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.2,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -2055,7 +2003,6 @@ GDP,11.4,Suse,Suse 12  64bit,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,ATAP,,,"KTAP, 
 GDP,11.4,Suse,Suse 15  64bit,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,CentOS,CentOS 7x,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
-GDP,11.4,Debian,Debian 11,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,Red Hat,Red Hat 7,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.1,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.2,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -2075,7 +2022,6 @@ GDP,11.4,Suse,Suse 12  64bit,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,ATAP,,,"KTAP, 
 GDP,11.4,Suse,Suse 15  64bit,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,CentOS,CentOS 7x,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
-GDP,11.4,Debian,Debian 11,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,Red Hat,Red Hat 7,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.1,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.2,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -2095,7 +2041,6 @@ GDP,11.4,Suse,Suse 12  64bit,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,ATAP,,,"KTAP, 
 GDP,11.4,Suse,Suse 15  64bit,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,CentOS,CentOS 7x,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
-GDP,11.4,Debian,Debian 11,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
 GDP,11.4,Red Hat,Red Hat 7,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.1,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.2,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -2116,7 +2061,6 @@ GDP,11.4,Suse,Suse 12  64bit,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,ATAP,,,"KTAP, A
 GDP,11.4,Suse,Suse 15  64bit,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
 GDP,11.4,CentOS,CentOS 7x,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
-GDP,11.4,Debian,Debian 11,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
 GDP,11.4,Red Hat,Red Hat 7,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.1,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.2,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -2137,7 +2081,6 @@ GDP,11.4,Suse,Suse 12  64bit,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,ATAP,,,"KTAP, A
 GDP,11.4,Suse,Suse 15  64bit,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 16.04,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
 GDP,11.4,CentOS,CentOS 7x,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
-GDP,11.4,Debian,Debian 11,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.4,Red Hat,Red Hat 7,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.1,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Red Hat,Red Hat 7.2,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
@@ -10151,7 +10094,6 @@ GDP,11.4,Ubuntu,Ubuntu 20.04,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,
 GDP,11.4,Ubuntu,Ubuntu 20.04,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,11.4,Ubuntu,Ubuntu 20.04,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,Ubuntu,Ubuntu 18.04,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
 GDP,11.4,Ubuntu,Ubuntu 16.04,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
 GDP,11.4,Ubuntu,Ubuntu 20.04,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
 GDP,11.4,Ubuntu,Ubuntu 20.04,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
@@ -10328,1067 +10270,24 @@ GDP,12.1,Ubuntu,Ubuntu 22.04,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KT
 GDP,12.1,Ubuntu,Ubuntu 22.04,EDB Postgres,EDB 12,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,12.1,Ubuntu,Ubuntu 22.04,EDB Postgres,EDB 15,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,12.1,Ubuntu,Ubuntu 22.04,Yugabyte,Yugabyte 2.20.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,AIX,AIX 7.1,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,AIX,AIX 7.1,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,AIX,AIX 7.1,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,AIX,AIX 7.1,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,AIX,AIX 7.1,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 9.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,AIX,AIX 7.1,IBM Db2 pureScale,IBM Db2 pureScale 10.1,"Db2 Exit, KTAP",KTAP,Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,AIX,AIX 7.1,IBM Db2 pureScale,IBM Db2 pureScale 10.5,"Db2 Exit, KTAP",KTAP,Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,AIX,AIX 7.1,IBM Db2 pureScale,IBM Db2 pureScale 11,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,AIX,AIX 7.1,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,AIX,AIX 7.1,IBM Db2 pureScale,IBM Db2 pureScale 9.8,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,Suse,Suse 12 64bit,Elasticsearch,Elasticsearch 8.10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,11.4,Suse,Suse 12 64bit,Elasticsearch,Elasticsearch 8.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,AIX,AIX 7.1,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,KTAP,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,AIX,AIX 7.1,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, KTAP",,"Informix Exit, KTAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,AIX,AIX 7.1,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, KTAP",,"Informix Exit, KTAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,AIX,AIX 7.1,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic Oracle Express XE is not supported
-GDP,11.4,AIX,AIX 7.1,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic Oracle Express XE is not supported
-GDP,11.4,AIX,AIX 7.1,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic Oracle Express XE is not supported
-GDP,11.4,AIX,AIX 7.1,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic Oracle Express XE is not supported
-GDP,11.4,AIX,AIX 7.1,Oracle,Oracle 19c,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic Oracle Express XE is not supported
-GDP,11.4,AIX,AIX 7.1,Oracle,Oracle 21c,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic Oracle Express XE is not supported
-GDP,11.4,AIX,AIX 7.1,Oracle RAC,Oracle RAC 11gR2,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,
-GDP,11.4,AIX,AIX 7.1,Oracle RAC,Oracle RAC 12.1,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,
-GDP,11.4,AIX,AIX 7.1,Oracle RAC,Oracle RAC 12.2,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,
-GDP,11.4,AIX,AIX 7.1,Oracle RAC,Oracle RAC 18c,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,
-GDP,11.4,AIX,AIX 7.1,Oracle RAC,Oracle RAC 19c,KTAP,KTAP,ATAP ASO SSL,,,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,AIX,AIX 7.1,Sybase ASE,Sybase ASE 15.7,KTAP,KTAP,ATAP SSL,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Sybase encrypted traffic. 16SP02 and 16SP03 are not supported for SSL connections
-GDP,11.4,AIX,AIX 7.1,Sybase ASE,Sybase ASE 16,KTAP,KTAP,ATAP SSL,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Sybase encrypted traffic.Encrypted traffic is not supported with Sybase ASE 16 SP3 or higher.
-GDP,11.4,AIX,AIX 7.1,Sybase IQ,Sybase IQ 16,KTAP,,ATAP x86_64 only,ATAP Sybase 16.1 does not support DB username,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",,,Yes,NA,Encrypted traffic is not supported with Sybase IQ 16 SP3 or higher.
-GDP,11.4,AIX,AIX 7.1,Sybase IQ,Sybase IQ 16.1,KTAP,,ATAP x86_64 only,ATAP Sybase 16.1 does not support DB username,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",,,Yes,NA,Encrypted traffic is not supported with Sybase IQ 16 SP3 or higher.
 GDP,11.4,Suse,Suse 15 64bit,Elasticsearch,Elasticsearch 8.10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,11.4,Suse,Suse 15 64bit,Elasticsearch,Elasticsearch 8.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 9.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,Suse,Suse 12 64bit,Elasticsearch,Elasticsearch 7.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,11.5,Suse,Suse 12 64bit,Elasticsearch,Elasticsearch 8.10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,11.5,Suse,Suse 12 64bit,Elasticsearch,Elasticsearch 8.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.5,Suse,Suse 12 64bit,Elasticsearch,Elasticsearch 7.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,12.0,Suse,Suse 12 64bit,Elasticsearch,Elasticsearch 7.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,11.5,Suse,Suse 15 64bit,Elasticsearch,Elasticsearch 8.10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,11.5,Suse,Suse 15 64bit,Elasticsearch,Elasticsearch 8.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 9.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
 GDP,11.4,Suse,Suse 15 64bit,Elasticsearch,Elasticsearch 7.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,12.0,Suse,Suse 12 64bit,Elasticsearch,Elasticsearch 8.10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,12.0,Suse,Suse 12 64bit,Elasticsearch,Elasticsearch 8.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
 GDP,11.5,Suse,Suse 15 64bit,Elasticsearch,Elasticsearch 7.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,12.0,Suse,Suse 15 64bit,Elasticsearch,Elasticsearch 7.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,12.0,Suse,Suse 15 64bit,Elasticsearch,Elasticsearch 8.10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,12.0,Suse,Suse 15 64bit,Elasticsearch,Elasticsearch 8.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 9.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 9.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 9.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 9.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 19c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 21c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 9.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 19c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 21c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 9.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 19c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 21c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 9.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 19c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 21c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 9.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 19c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 21c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 9.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 19c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 21c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 9.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 19c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 21c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP",KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Debian,Debian 10,IBM Db2,IBM Db2 9.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 10.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Debian,Debian 10,IBM Db2 pureScale,IBM Db2 pureScale 9.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL Encryption supported only using Db2 EXIT
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Ubuntu,Ubuntu 14.04,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,Informix Exit supported with 12.10 and higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 5.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Debian,Debian 10,MySQL,MySQL 8.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 10,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 11,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 12.7,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 13.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 14.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 15.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
-GDP,11.4,Ubuntu,Ubuntu 14.04,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Debian,Debian 10,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 10.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V10.1FP4 or higher For Db2 LUW. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 10.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to capture UID chain using Db2 Exit is V105FP3 or higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 11.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2,IBM Db2 9.7,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,The versions of Db2 required in order to use Db2 Exit is V97FP10 or higher. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Db2 pureScale,IBM Db2 pureScale 11.5,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 11.7,KTAP,KTAP,,ATAP,,"KTAP, ATAP",KTAP,KTAP,KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 12.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,IBM Informix,IBM Informix 14.1,"Informix Exit, KTAP","Informix Exit, KTAP",Informix Exit,"Informix Exit, ATAP",,"Informix Exit, KTAP, ATAP","Informix Exit, KTAP","Informix Exit, KTAP",KTAP,,Yes,NA,SLES 11 PPC64 Big Endian system only. Informix Exit supported with 12.10. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 11gR2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 12.1,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 12.2,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 18c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 19c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
-GDP,11.4,Zlinux,Zlinux Suse 11  32bit 64bit,Oracle,Oracle 21c,KTAP,KTAP,ATAP ASO SSL,,KTAP,"KTAP, ATAP",KTAP,KTAP,,KTAP,Yes,NA,Guardium Client IP and Analyzed Client IP are not supported in Oracle SSL traffic. SLES 11 PPC64 Big Endian system only. Oracle Express XE is not supported. ATAP with Linux 2.6.36 and higher only.
 GDP,11.4,IBM i,IBM i 6.1,IBM Db2,IBM Db2 6.1,ITAP,ITAP,ITAP,,,,,,,,,,Support is provided by the Db2 for i STAP
 GDP,11.4,IBM i,IBM i 7.1,IBM Db2,IBM Db2 7.1,ITAP,ITAP,ITAP,,,,,,,,,,Support is provided by the Db2 for i STAP
 GDP,11.4,IBM i,IBM i 7.2,IBM Db2,IBM Db2 7.2,ITAP,ITAP,ITAP,,,,,,,,,,Support is provided by the Db2 for i STAP


### PR DESCRIPTION
As per release notes deprecated the platforms for 11.4 version.
https://www.ibm.com/support/pages/node/7185957