### PR TITLE
GRD-96391 New supported currency items from sniffer 4008 4080 patch

### DIFF
--- a/consolidation-script2/data/input/OnPrem_Stap.csv
+++ b/consolidation-script2/data/input/OnPrem_Stap.csv
@@ -9787,16 +9787,6 @@ GDP,12.1,Red Hat,Red Hat 7.8,Redis,Redis 7.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,
 GDP,12.1,Red Hat,Red Hat 7.9,Redis,Redis 7.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,12.1,Red Hat,Red Hat 8,Redis,Redis 7.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,12.1,Red Hat,Red Hat 9,Redis,Redis 7.3,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,12.1,Red Hat,Red Hat 7,Redis,Redis 7.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,12.1,Red Hat,Red Hat 7.1,Redis,Redis 7.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,12.1,Red Hat,Red Hat 7.2,Redis,Redis 7.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,12.1,Red Hat,Red Hat 7.3,Redis,Redis 7.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,12.1,Red Hat,Red Hat 7.4,Redis,Redis 7.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,12.1,Red Hat,Red Hat 7.5,Redis,Redis 7.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,12.1,Red Hat,Red Hat 7.6,Redis,Redis 7.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,12.1,Red Hat,Red Hat 7.7,Redis,Redis 7.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,12.1,Red Hat,Red Hat 7.8,Redis,Redis 7.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
-GDP,12.1,Red Hat,Red Hat 7.9,Redis,Redis 7.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,12.1,Red Hat,Red Hat 8,Redis,Redis 7.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,12.1,Red Hat,Red Hat 9,Redis,Redis 7.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
 GDP,12.1,CentOS,CentOS 7x,SAP HANA,SAP HANA 1,KTAP,KTAP,,,,KTAP,KTAP,KTAP,,,,NA,
@@ -12506,7 +12496,7 @@ GDP,12.1,Windows Server,Windows Server 2025,MariaDB,MariaDB 10.1,STAP,STAP,,,,ST
 GDP,12.1,Windows Server,Windows Server 2025,MariaDB,MariaDB 10.6,STAP,STAP,,,,STAP,STAP,NA,NA,,STAP,TCP,
 GDP,12.1,Windows Server,Windows Server 2025,MariaDB,MariaDB 10.7,STAP,STAP,,,,STAP,STAP,NA,NA,,STAP,TCP,
 GDP,12.1,Windows Server,Windows Server 2025,MariaDB,MariaDB 11.2,STAP,STAP,,,,STAP,STAP,NA,NA,,STAP,TCP,
-GDP,12.1,Windows Server,Windows Server 2025,MongoDB,MongoDB 7.0,,STAP,,NA,STAP,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,12.1,Windows Server,Windows Server 2025,MongoDB,MongoDB 8.0.5,,STAP,,NA,STAP,STAP,STAP,NA,NA,,STAP,TCP,
 GDP,12.1,Windows Server,Windows Server 2025,MongoDB,MongoDB 7.0.1,,STAP,,NA,STAP,STAP,STAP,NA,NA,,STAP,TCP,
 GDP,12.1,Windows Server,Windows Server 2025,MS SQL Server,MS SQL Server 2017,STAP,STAP,STAP,NA,STAP,STAP,STAP,NA,NA,STAP,STAP,"TCP, NMP",For the Redact scrub function with MSSQL Server 2016 and laterGuardium can parse SQL statements but the encrypted columns cannot be read.
 GDP,12.1,Windows Server,Windows Server 2025,MS SQL Server,MS SQL Server 2019,STAP,STAP,STAP,NA,STAP,STAP,STAP,NA,NA,STAP,STAP,"TCP, NMP",Force Encryption is supported in MS SQL Server 2019.
@@ -12567,3 +12557,304 @@ GDP,11.5,Ubuntu,Ubuntu 24.04,PostgreSQL,PostgreSQL 16.0,KTAP,KTAP,,,,KTAP,KTAP,K
 GDP,11.5,Ubuntu,Ubuntu 24.04,PostgreSQL,PostgreSQL 9.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
 GDP,11.5,Ubuntu,Ubuntu 24.04,PostgreSQL,PostgreSQL 9.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,SSL encryption supported PostgreSQL bind variables supported
 GDP,11.5,Ubuntu,Ubuntu 24.04,PostgreSQL,PostgreSQL 9.6,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,11.4,CentOS,CentOS 7x,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
+GDP,11.4,Debian,Debian 11,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,11.4,Red Hat,Red Hat 7,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Red Hat,Red Hat 7.1,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Red Hat,Red Hat 7.2,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Red Hat,Red Hat 7.3,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Red Hat,Red Hat 7.4,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Red Hat,Red Hat 7.5,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Red Hat,Red Hat 7.6,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Red Hat,Red Hat 7.7,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Red Hat,Red Hat 7.8,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Red Hat,Red Hat 8,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Red Hat,Red Hat 9,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Solaris,Solaris 10,PostgreSQL,PostgreSQL 17.2,KTAP 9.3 to 9.5,KTAP9.3 to 9.5,ATAP 9.4 9.5,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported
+GDP,11.4,Solaris,Solaris 11.2,PostgreSQL,PostgreSQL 17.2,KTAP 9.3 to 9.5,KTAP9.3 to 9.5,ATAP 9.4 9.5,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported
+GDP,11.4,Solaris,Solaris 11.3,PostgreSQL,PostgreSQL 17.2,KTAP 9.3 to 9.5,KTAP9.3 to 9.5,ATAP 9.4 9.5,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported
+GDP,11.4,Solaris,Solaris 11.4,PostgreSQL,PostgreSQL 17.2,KTAP 9.3 to 9.5,KTAP9.3 to 9.5,ATAP 9.4 9.5,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,Requires V11.0 Stap. PostgreSQL bind variables supported
+GDP,11.4,Suse,Suse 12  64bit,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Suse,Suse 15  64bit,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Ubuntu,Ubuntu 16.04,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,11.5,CentOS,CentOS 7x,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
+GDP,11.5,Debian,Debian 11,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,11.5,Red Hat,Red Hat 7,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Red Hat,Red Hat 7.1,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Red Hat,Red Hat 7.2,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Red Hat,Red Hat 7.3,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Red Hat,Red Hat 7.4,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Red Hat,Red Hat 7.5,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Red Hat,Red Hat 7.6,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Red Hat,Red Hat 7.7,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Red Hat,Red Hat 7.8,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Red Hat,Red Hat 8,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Red Hat,Red Hat 9,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Solaris,Solaris 10,PostgreSQL,PostgreSQL 17.2,KTAP 9.3 to 9.5,KTAP9.3 to 9.5,ATAP 9.4 9.5,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported
+GDP,11.5,Solaris,Solaris 11.2,PostgreSQL,PostgreSQL 17.2,KTAP 9.3 to 9.5,KTAP9.3 to 9.5,ATAP 9.4 9.5,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported
+GDP,11.5,Solaris,Solaris 11.3,PostgreSQL,PostgreSQL 17.2,KTAP 9.3 to 9.5,KTAP9.3 to 9.5,ATAP 9.4 9.5,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported
+GDP,11.5,Solaris,Solaris 11.4,PostgreSQL,PostgreSQL 17.2,KTAP 9.3 to 9.5,KTAP9.3 to 9.5,ATAP 9.4 9.5,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,Requires V11.0 Stap. PostgreSQL bind variables supported
+GDP,11.5,Suse,Suse 12 64bit,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Suse,Suse 15 64bit,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Ubuntu,Ubuntu 16.04,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,12.0,CentOS,CentOS 7x,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
+GDP,12.0,Debian,Debian 11,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,12.0,Red Hat,Red Hat 7,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Red Hat,Red Hat 7.1,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Red Hat,Red Hat 7.2,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Red Hat,Red Hat 7.3,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Red Hat,Red Hat 7.4,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Red Hat,Red Hat 7.5,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Red Hat,Red Hat 7.6,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Red Hat,Red Hat 7.7,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Red Hat,Red Hat 7.8,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Red Hat,Red Hat 8,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Red Hat,Red Hat 9,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Solaris,Solaris 10,PostgreSQL,PostgreSQL 17.2,KTAP 9.3 to 9.5,KTAP9.3 to 9.5,ATAP 9.4 9.5,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported
+GDP,12.0,Solaris,Solaris 11.2,PostgreSQL,PostgreSQL 17.2,KTAP 9.3 to 9.5,KTAP9.3 to 9.5,ATAP 9.4 9.5,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported
+GDP,12.0,Solaris,Solaris 11.3,PostgreSQL,PostgreSQL 17.2,KTAP 9.3 to 9.5,KTAP9.3 to 9.5,ATAP 9.4 9.5,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported
+GDP,12.0,Solaris,Solaris 11.4,PostgreSQL,PostgreSQL 17.2,KTAP 9.3 to 9.5,KTAP9.3 to 9.5,ATAP 9.4 9.5,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,Requires V11.0 Stap. PostgreSQL bind variables supported
+GDP,12.0,Suse,Suse 12  64bit,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Suse,Suse 15  64bit,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Ubuntu,Ubuntu 16.04,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,12.1,CentOS,CentOS 7x,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,ATAP with Linux 2.6.36 and higher only
+GDP,12.1,Debian,Debian 11,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,12.1,Debian,Debian 12.0,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,12.1,Red Hat,Red Hat 7,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Red Hat,Red Hat 7.1,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Red Hat,Red Hat 7.2,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Red Hat,Red Hat 7.3,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Red Hat,Red Hat 7.4,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Red Hat,Red Hat 7.5,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Red Hat,Red Hat 7.6,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Red Hat,Red Hat 7.7,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Red Hat,Red Hat 7.8,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Red Hat,Red Hat 8,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Red Hat,Red Hat 9,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Solaris,Solaris 10,PostgreSQL,PostgreSQL 17.2,KTAP 9.3 to 9.5,KTAP9.3 to 9.5,ATAP 9.4 9.5,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported
+GDP,12.1,Solaris,Solaris 11.2,PostgreSQL,PostgreSQL 17.2,KTAP 9.3 to 9.5,KTAP9.3 to 9.5,ATAP 9.4 9.5,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported
+GDP,12.1,Solaris,Solaris 11.3,PostgreSQL,PostgreSQL 17.2,KTAP 9.3 to 9.5,KTAP9.3 to 9.5,ATAP 9.4 9.5,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,PostgreSQL bind variables supported
+GDP,12.1,Solaris,Solaris 11.4,PostgreSQL,PostgreSQL 17.2,KTAP 9.3 to 9.5,KTAP9.3 to 9.5,ATAP 9.4 9.5,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,Requires V11.0 Stap. PostgreSQL bind variables supported
+GDP,12.1,Suse,Suse 12  64bit,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Suse,Suse 15  64bit,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,ATAP,,,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,Yes,NA,SSL encryption supported. PostgreSQL bind variables supported. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Ubuntu,Ubuntu 16.04,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,11.4,Ubuntu,Ubuntu 20.04,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,11.5,Ubuntu,Ubuntu 20.04,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,12.0,Ubuntu,Ubuntu 20.04,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,12.1,Ubuntu,Ubuntu 20.04,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,12.0,Ubuntu,Ubuntu 22.04,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,12.1,Ubuntu,Ubuntu 22.04,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,11.4,Windows Server,Windows Server 2016,PostgreSQL,PostgreSQL 17.4,STAP,STAP,,NA,,STAP,STAP,NA,NA,STAP,STAP,TCP,Windows does not support encryption for PostgreSQL
+GDP,11.4,Windows Server,Windows Server 2019,PostgreSQL,PostgreSQL 17.4,STAP,STAP,,NA,,STAP,STAP,NA,NA,STAP,STAP,TCP,Windows does not support encryption for PostgreSQL
+GDP,11.4,Windows Server,Windows Server 2022,PostgreSQL,PostgreSQL 17.4,STAP,STAP,,NA,,STAP,STAP,NA,NA,STAP,STAP,TCP,Windows does not support encryption for PostgreSQL
+GDP,11.5,Windows Server,Windows Server 2016,PostgreSQL,PostgreSQL 17.4,STAP,STAP,,NA,,STAP,STAP,NA,NA,STAP,STAP,TCP,Windows does not support encryption for PostgreSQL
+GDP,11.5,Windows Server,Windows Server 2019,PostgreSQL,PostgreSQL 17.4,STAP,STAP,,NA,,STAP,STAP,NA,NA,STAP,STAP,TCP,Windows does not support encryption for PostgreSQL
+GDP,11.5,Windows Server,Windows Server 2022,PostgreSQL,PostgreSQL 17.4,STAP,STAP,,NA,,STAP,STAP,NA,NA,STAP,STAP,TCP,Windows does not support encryption for PostgreSQL
+GDP,12.0,Windows Server,Windows Server 2016,PostgreSQL,PostgreSQL 17.4,STAP,STAP,,NA,,STAP,STAP,NA,NA,STAP,STAP,TCP,Windows does not support encryption for PostgreSQL
+GDP,12.0,Windows Server,Windows Server 2019,PostgreSQL,PostgreSQL 17.4,STAP,STAP,,NA,,STAP,STAP,NA,NA,STAP,STAP,TCP,Windows does not support encryption for PostgreSQL
+GDP,12.0,Windows Server,Windows Server 2022,PostgreSQL,PostgreSQL 17.4,STAP,STAP,,NA,,STAP,STAP,NA,NA,STAP,STAP,TCP,Windows does not support encryption for PostgreSQL
+GDP,12.1,Windows Server,Windows Server 2016,PostgreSQL,PostgreSQL 17.4,STAP,STAP,,NA,,STAP,STAP,NA,NA,STAP,STAP,TCP,Windows does not support encryption for PostgreSQL
+GDP,12.1,Windows Server,Windows Server 2019,PostgreSQL,PostgreSQL 17.4,STAP,STAP,,NA,,STAP,STAP,NA,NA,STAP,STAP,TCP,Windows does not support encryption for PostgreSQL
+GDP,12.1,Windows Server,Windows Server 2022,PostgreSQL,PostgreSQL 17.4,STAP,STAP,,NA,,STAP,STAP,NA,NA,STAP,STAP,TCP,Windows does not support encryption for PostgreSQL
+GDP,11.5,Ubuntu,Ubuntu 22.04,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,12.1,Ubuntu,Ubuntu 24.04,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,12.1,Windows Server,Windows Server 2025,PostgreSQL,PostgreSQL 17.4,STAP,STAP,,NA,,STAP,STAP,NA,NA,STAP,STAP,TCP,Windows does not support encryption for PostgreSQL
+GDP,11.5,Ubuntu,Ubuntu 24.04,PostgreSQL,PostgreSQL 17.2,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,PostgreSQL bind variables supported
+GDP,11.4,Windows Server,Windows Server 2022,MariaDB,MariaDB 11.2,STAP,STAP,,,,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,11.5,Windows Server,Windows Server 2022,MariaDB,MariaDB 11.2,STAP,STAP,,,,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,12.0,Windows Server,Windows Server 2022,MariaDB,MariaDB 11.2,STAP,STAP,,,,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,11.4,CentOS,CentOS 7x,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,11.4,Red Hat,Red Hat 7,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.1,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.2,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.3,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.4,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.5,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.6,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.7,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.8,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 7.9,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 8,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Red Hat,Red Hat 9,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.4,Suse,Suse 12  64bit,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
+GDP,11.4,Suse,Suse 15  64bit,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
+GDP,11.5,CentOS,CentOS 7x,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,11.5,Red Hat,Red Hat 7,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.1,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.2,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.3,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.4,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.5,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.6,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.7,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.8,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 7.9,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 8,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Red Hat,Red Hat 9,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,11.5,Suse,Suse 12 64bit,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
+GDP,11.5,Suse,Suse 15 64bit,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
+GDP,12.0,CentOS,CentOS 7x,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,12.0,Red Hat,Red Hat 7,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.1,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.2,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.3,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.4,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.5,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.6,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.7,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.8,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 7.9,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 8,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Red Hat,Red Hat 9,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.0,Suse,Suse 12  64bit,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
+GDP,12.0,Suse,Suse 15  64bit,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
+GDP,12.1,CentOS,CentOS 7x,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,12.1,Red Hat,Red Hat 7,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.1,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.2,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.3,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.4,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.5,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.6,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.7,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.8,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 7.9,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 8,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Red Hat,Red Hat 9,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE
+GDP,12.1,Suse,Suse 12  64bit,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
+GDP,12.1,Suse,Suse 15  64bit,MariaDB,MariaDB 11.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,Do not support encryption SLES 12 PPC64LE Little Endian system only
+GDP,12.1,Windows Server,Windows Server 2022,MariaDB,MariaDB 11.7,STAP,STAP,,,,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,12.1,Windows Server,Windows Server 2025,MariaDB,MariaDB 11.7,STAP,STAP,,,,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,11.4,Windows Server,Windows Server 2022,MariaDB,MariaDB 11.7,STAP,STAP,,,,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,11.5,Windows Server,Windows Server 2022,MariaDB,MariaDB 11.7,STAP,STAP,,,,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,12.0,Windows Server,Windows Server 2022,MariaDB,MariaDB 11.7,STAP,STAP,,,,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,11.4,Red Hat,Red Hat 7,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,11.4,Red Hat,Red Hat 7.1,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,11.4,Red Hat,Red Hat 7.2,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,11.4,Red Hat,Red Hat 7.3,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,11.4,Red Hat,Red Hat 7.4,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,11.4,Red Hat,Red Hat 7.5,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,11.4,Red Hat,Red Hat 7.6,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,11.4,Red Hat,Red Hat 7.7,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,11.4,Red Hat,Red Hat 7.8,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,11.4,Red Hat,Red Hat 8,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,11.4,Red Hat,Red Hat 9,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.0,Red Hat,Red Hat 7,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.0,Red Hat,Red Hat 7.1,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.0,Red Hat,Red Hat 7.2,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.0,Red Hat,Red Hat 7.3,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.0,Red Hat,Red Hat 7.4,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.0,Red Hat,Red Hat 7.5,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.0,Red Hat,Red Hat 7.6,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.0,Red Hat,Red Hat 7.7,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.0,Red Hat,Red Hat 7.8,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.0,Red Hat,Red Hat 7.9,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.0,Red Hat,Red Hat 8,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.0,Red Hat,Red Hat 9,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.1,Red Hat,Red Hat 7,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.1,Red Hat,Red Hat 7.1,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.1,Red Hat,Red Hat 7.2,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.1,Red Hat,Red Hat 7.3,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.1,Red Hat,Red Hat 7.4,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.1,Red Hat,Red Hat 7.5,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.1,Red Hat,Red Hat 7.6,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.1,Red Hat,Red Hat 7.7,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.1,Red Hat,Red Hat 7.8,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.1,Red Hat,Red Hat 7.9,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.1,Red Hat,Red Hat 8,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,12.1,Red Hat,Red Hat 9,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,,KTAP,KTAP,,,NA,
+GDP,11.4,Suse,Suse 12 64bit,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,11.4,Suse,Suse 15 64bit,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,11.5,Suse,Suse 12 64bit,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,11.5,Suse,Suse 15 64bit,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,12.0,Suse,Suse 12 64bit,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,12.0,Suse,Suse 15 64bit,Elasticsearch,Elasticsearch 8.15.5,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,12.0,Windows Server,Windows Server 2016,Elasticsearch,Elasticsearch 8.17,STAP,STAP,,,,STAP,,NA,NA,,STAP,TCP,
+GDP,12.0,Windows Server,Windows Server 2019,Elasticsearch,Elasticsearch 8.17,STAP,STAP,,,,STAP,,NA,NA,,STAP,TCP,
+GDP,12.0,Windows Server,Windows Server 2022,Elasticsearch,Elasticsearch 8.17,STAP,STAP,,,,STAP,,NA,NA,,STAP,TCP,
+GDP,12.1,Windows Server,Windows Server 2016,Elasticsearch,Elasticsearch 8.17,STAP,STAP,,,,STAP,,NA,NA,,STAP,TCP,
+GDP,12.1,Windows Server,Windows Server 2019,Elasticsearch,Elasticsearch 8.17,STAP,STAP,,,,STAP,,NA,NA,,STAP,TCP,
+GDP,12.1,Windows Server,Windows Server 2022,Elasticsearch,Elasticsearch 8.17,STAP,STAP,,,,STAP,,NA,NA,,STAP,TCP,
+GDP,12.1,Windows Server,Windows Server 2025,Elasticsearch,Elasticsearch 8.17,STAP,STAP,,,,STAP,,NA,NA,,STAP,TCP,
+GDP,11.5,Windows Server,Windows Server 2016,Elasticsearch,Elasticsearch 8.17,STAP,STAP,,,,STAP,,NA,NA,,STAP,TCP,
+GDP,11.5,Windows Server,Windows Server 2019,Elasticsearch,Elasticsearch 8.17,STAP,STAP,,,,STAP,,NA,NA,,STAP,TCP,
+GDP,11.5,Windows Server,Windows Server 2022,Elasticsearch,Elasticsearch 8.17,STAP,STAP,,,,STAP,,NA,NA,,STAP,TCP,
+GDP,11.4,Windows Server,Windows Server 2016,Elasticsearch,Elasticsearch 8.17,STAP,STAP,,,,STAP,,NA,NA,,STAP,TCP,
+GDP,11.4,Windows Server,Windows Server 2019,Elasticsearch,Elasticsearch 8.17,STAP,STAP,,,,STAP,,NA,NA,,STAP,TCP,
+GDP,11.4,Windows Server,Windows Server 2022,Elasticsearch,Elasticsearch 8.17,STAP,STAP,,,,STAP,,NA,NA,,STAP,TCP,
+GDP,11.4,Windows Server,Windows Server 2022,IBM Db2,IBM Db2 12.1,STAP also with Db2 Exit,"Db2 Exit, STAP",SSL,NA,,STAP Except Db2 Exit,STAP Except Db2 Exit,NA,NA,STAP,STAP,"TCP, SHM",SSL Encryption supported only using Db2 EXIT
+GDP,11.5,Windows Server,Windows Server 2022,IBM Db2,IBM Db2 12.1,STAP also with Db2 Exit,"Db2 Exit, STAP",SSL,NA,,STAP Except Db2 Exit,STAP Except Db2 Exit,NA,NA,STAP,STAP,"TCP, SHM",SSL Encryption supported only using Db2 EXIT
+GDP,12.0,Windows Server,Windows Server 2022,IBM Db2,IBM Db2 12.1,STAP also with Db2 Exit,"Db2 Exit, STAP",SSL,NA,,STAP Except Db2 Exit,STAP Except Db2 Exit,NA,NA,STAP,STAP,"TCP, SHM",SSL Encryption supported only using Db2 EXIT
+GDP,12.1,Windows Server,Windows Server 2022,IBM Db2,IBM Db2 12.1,STAP also with Db2 Exit,"Db2 Exit, STAP",SSL,NA,,STAP Except Db2 Exit,STAP Except Db2 Exit,NA,NA,STAP,STAP,"TCP, SHM",SSL Encryption supported only using Db2 EXIT
+GDP,12.1,Windows Server,Windows Server 2025,IBM Db2,IBM Db2 12.1,STAP also with Db2 Exit,"Db2 Exit, STAP",SSL,NA,,STAP Except Db2 Exit,STAP Except Db2 Exit,NA,NA,STAP,STAP,"TCP, SHM",SSL Encryption supported only using Db2 EXIT
+GDP,11.4,Debian,Debian 11,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
+GDP,11.4,Red Hat,Red Hat 9,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Suse,Suse 15  64bit,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Zlinux,Zlinux Suse 15  64bit,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Zlinux,Zlinux Ubuntu 22.04,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.5,AIX,AIX 7.3,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,
+GDP,11.5,Debian,Debian 11,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
+GDP,11.5,Red Hat,Red Hat 9,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Suse,Suse 15 64bit,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Zlinux,Zlinux Suse 15 64bit,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Zlinux,Zlinux Ubuntu 22.04,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.0,AIX,AIX 7.3,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,
+GDP,12.0,Debian,Debian 11,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
+GDP,12.0,Red Hat,Red Hat 9,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Suse,Suse 15  64bit,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,Db2 Exit,,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only
+GDP,12.0,Zlinux,Zlinux Suse 15  64bit,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Zlinux,Zlinux Ubuntu 22.-4,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.1,AIX,AIX 7.3,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",,,Yes,NA,
+GDP,12.1,Debian,Debian 11,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
+GDP,12.1,Debian,Debian 12.0,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP",Db2 Exit,Db2 Exit,Db2 Exit,,Db2 Exit,Db2 Exit,Db2 Exit,Db2 Exit,,Yes,NA,
+GDP,12.1,Red Hat,Red Hat 9,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Suse,Suse 15  64bit,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,Db2 Exit,,"Db2 Exit, KTAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only
+GDP,12.1,Zlinux,Zlinux Suse 15  64bit,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,,Yes,NA,SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Zlinux,Zlinux Ubuntu 22.04,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.0,Ubuntu,Ubuntu 22.04,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,12.1,Ubuntu,Ubuntu 22.04,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.5,Ubuntu,Ubuntu 22.04,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, KTAP",,KTAP,KTAP,KTAP,KTAP,,Yes,NA,
+GDP,11.5,Zlinux,Zlinux Red Hat 9,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Zlinux,Zlinux Red Hat 9,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Zlinux,Zlinux Red Hat 9,IBM Db2,IBM Db2 12.1,"Db2 Exit, KTAP","Db2 Exit, KTAP",Db2 Exit,"Db2 Exit, ATAP",,"Db2 Exit, KTAP, ATAP",KTAP,"Db2 Exit, KTAP",KTAP,KTAP,Yes,NA,Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Red Hat,Red Hat 8,MongoDB,MongoDB 8.0.5,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Red Hat,Red Hat 9,MongoDB,MongoDB 8.0.5,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Suse,Suse 12  64bit,MongoDB,MongoDB 8.0.5,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Suse,Suse 15  64bit,MongoDB,MongoDB 8.0.5,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Red Hat,Red Hat 8,MongoDB,MongoDB 8.0.5,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Red Hat,Red Hat 9,MongoDB,MongoDB 8.0.5,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Suse,Suse 12 64bit,MongoDB,MongoDB 8.0.5,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,11.5,Suse,Suse 15 64bit,MongoDB,MongoDB 8.0.5,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Red Hat,Red Hat 8,MongoDB,MongoDB 8.0.5,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Red Hat,Red Hat 9,MongoDB,MongoDB 8.0.5,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Suse,Suse 12  64bit,MongoDB,MongoDB 8.0.5,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,12.0,Suse,Suse 15  64bit,MongoDB,MongoDB 8.0.5,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Red Hat,Red Hat 8,MongoDB,MongoDB 8.0.5,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Red Hat,Red Hat 9,MongoDB,MongoDB 8.0.5,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. Little endian and Big endian supported on Power 8 RHEL 7.x7.6 PPC64LE. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Suse,Suse 12  64bit,MongoDB,MongoDB 8.0.5,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,12.1,Suse,Suse 15  64bit,MongoDB,MongoDB 8.0.5,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP",KTAP,"KTAP, ATAP (ATAP only when configured for real Ips)",KTAP,,,NA,supported MongoDB mgo client version 2 3.2.1 3.4.2 3.6 4.0. MongoDB Compass client versions 1.14 1.15 1.16 3.6 4.0. SLES 12 PPC64LE Little Endian system only. ATAP with Linux 2.6.36 and higher only.
+GDP,11.4,Windows Server,Windows Server 2016,MongoDB,MongoDB 8.0.5,,STAP,,NA,STAP,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,11.4,Windows Server,Windows Server 2019,MongoDB,MongoDB 8.0.5,,STAP,,NA,STAP,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,11.4,Windows Server,Windows Server 2022,MongoDB,MongoDB 8.0.5,,STAP,,NA,STAP,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,11.5,Windows Server,Windows Server 2016,MongoDB,MongoDB 8.0.5,,STAP,,NA,STAP,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,11.5,Windows Server,Windows Server 2019,MongoDB,MongoDB 8.0.5,,STAP,,NA,STAP,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,11.5,Windows Server,Windows Server 2022,MongoDB,MongoDB 8.0.5,,STAP,,NA,STAP,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,12.0,Windows Server,Windows Server 2016,MongoDB,MongoDB 8.0.5,,STAP,,NA,STAP,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,12.0,Windows Server,Windows Server 2019,MongoDB,MongoDB 8.0.5,,STAP,,NA,STAP,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,12.0,Windows Server,Windows Server 2022,MongoDB,MongoDB 8.0.5,,STAP,,NA,STAP,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,12.1,Windows Server,Windows Server 2016,MongoDB,MongoDB 8.0.5,,STAP,,NA,STAP,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,12.1,Windows Server,Windows Server 2019,MongoDB,MongoDB 8.0.5,,STAP,,NA,STAP,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,12.1,Windows Server,Windows Server 2022,MongoDB,MongoDB 8.0.5,,STAP,,NA,STAP,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,11.5,Amazon Linux,Amazon Linux 2023,MongoDB,MongoDB 8.0.5,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP ",KTAP,"KTAP, ATAP",KTAP,,,NA,supported on x86 and Arm64
+GDP,12.1,Amazon Linux,Amazon Linux 2023,MongoDB,MongoDB 8.0.5,KTAP,KTAP,ATAP,,KTAP,"KTAP, ATAP ",KTAP,"KTAP, ATAP",KTAP,,,NA,supported on x86 and Arm64
+GDP,12.1,Windows Server,Windows Server 2025,MongoDB,MongoDB 8.0.5,,STAP,,NA,STAP,STAP,STAP,NA,NA,,STAP,TCP,
+GDP,12.1,Red Hat,Red Hat 8,Redis,Redis 7.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,12.1,Red Hat,Red Hat 9,Redis,Redis 7.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,11.5,Red Hat,Red Hat 8,Redis,Redis 7.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,11.5,Red Hat,Red Hat 9,Redis,Redis 7.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,11.5,Red Hat,Red Hat 8,Redis,Redis 7.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,11.5,Red Hat,Red Hat 9,Redis,Redis 7.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,12.0,Red Hat,Red Hat 8,Redis,Redis 7.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,12.0,Red Hat,Red Hat 9,Redis,Redis 7.4,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,12.0,Red Hat,Red Hat 8,Redis,Redis 7.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,
+GDP,12.0,Red Hat,Red Hat 9,Redis,Redis 7.8,KTAP,KTAP,,,,KTAP,KTAP,KTAP,KTAP,,,NA,


### PR DESCRIPTION
GRD-96391 New supported currency items from sniffer 4008 4080 patch

- Redis 7.4 and 7.8 is not supported on RHEL 7 so removed RHEL 7 and Centos7x : https://redis.io/docs/latest/operate/rs/references/supported-platforms/
- MongoDB not supported on Windows Server 2025. MongoDB 8.0.5 kept for Windows Server 2025  https://www.mongodb.com/docs/manual/administration/production-notes/
- Added other DBs supported in https://ibm-datasecurity.atlassian.net/browse/GRD-96391
- Not mentioned anything for VectorDB syntax specifically in support matrix.
