### PR TITLE
GRD-99405 close tooltip clicking anywhere on screen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,12 +3,15 @@ import "./styles/connection_doc.scss";
 import MainPage from "./components/MainPage";
 import "./styles/globals.scss";
 import React from "react";
+import { TooltipProvider } from "./context/TooltipContext";
 
-function App()  {
+function App() {
   return (
-    <main>
-      <MainPage />
-    </main>
+    <TooltipProvider>
+      <main>
+        <MainPage />
+      </main>
+    </TooltipProvider>
   );
 }
 

--- a/src/components/DataSourceModal/ModalLeftPanel/PanelCollapsibleInfo.js
+++ b/src/components/DataSourceModal/ModalLeftPanel/PanelCollapsibleInfo.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { generateAccordianItem } from "../../../helpers/helpers";
+import { useTooltip } from '../../../context/TooltipContext';
 
 // TODO: Split into 3 tooltips
 
@@ -8,8 +9,6 @@ import { generateAccordianItem } from "../../../helpers/helpers";
 // Information is retrieved from summary.json
 export default function PanelCollapsibleInfo({
   selectedMethodData,
-  toolTipOpen,
-  setToolTipOpen,
 }) {
   const filteredSections = selectedMethodData.method_info.filter(
     (section) =>
@@ -18,8 +17,11 @@ export default function PanelCollapsibleInfo({
       section.content[0] != null
   );
 
-  const handleTooltipClick = (index) => {
-    setToolTipOpen(toolTipOpen.map((isOpen, i) => (i === index ? !isOpen : false)));
+  const { openTooltipId, setOpenTooltipId } = useTooltip();
+
+  const handleTooltipClick = (id, e) => {
+    e.stopPropagation();
+    setOpenTooltipId(openTooltipId === id ? null : id); // toggle
   };
 
   return (
@@ -27,10 +29,11 @@ export default function PanelCollapsibleInfo({
       <br />
       <h6> About {selectedMethodData.method_name}</h6>
       <ul>
-        <li onClick={() => handleTooltipClick(0)} className="tooltip" id={`tooltip${toolTipOpen[0]}`}>
+        {/* <li onClick={() => handleTooltipClick(0)} className="tooltip" id={`tooltip${toolTipOpen[0]}`}> */}
+        <li onClick={(e) => handleTooltipClick(0, e)} className="tooltip" id={`tooltip-${openTooltipId === 0 ? 'open' : 'closed'}`}>
           {" "}
           How it works
-          {toolTipOpen[0] ? (
+          {openTooltipId === 0 ? (
             <span className="tooltiptext">
               {generateAccordianItem(
                 selectedMethodData.method_info.filter(
@@ -43,10 +46,11 @@ export default function PanelCollapsibleInfo({
           ) : null}
         </li>
         <br />
-        <li onClick={() => handleTooltipClick(1)} className="tooltip" id={`tooltip${toolTipOpen[1]}`}>
+        {/* <li onClick={() => handleTooltipClick(1)} className="tooltip" id={`tooltip${toolTipOpen[1]}`}> */}
+        <li onClick={(e) => handleTooltipClick(1, e)} className="tooltip" id={`tooltip-${openTooltipId === 1 ? 'open' : 'closed'}`}>
           {" "}
           Benefits and Considerations
-          {toolTipOpen[1] ? (
+          {openTooltipId === 1 ? (
             <span className="tooltiptext">
               <h6>Skill Level:</h6>{" "}
               <div>
@@ -80,10 +84,11 @@ export default function PanelCollapsibleInfo({
           ) : null}
         </li>
         <br />
-        <li onClick={() => handleTooltipClick(2)} className="tooltip" id={`tooltip${toolTipOpen[2]}`}>
+        {/* <li onClick={() => handleTooltipClick(2)} className="tooltip" id={`tooltip${toolTipOpen[2]}`}> */}
+        <li onClick={(e) => handleTooltipClick(2, e)} className="tooltip" id={`tooltip-${openTooltipId === 2 ? 'open' : 'closed'}`}>
           {" "}
           Getting Started
-          {toolTipOpen[2] ? (
+          {openTooltipId === 2 ? (
             <span className="tooltiptext">
               <h6>Information you will need: </h6>
               <div>
@@ -126,6 +131,4 @@ PanelCollapsibleInfo.propTypes = {
       })
     ).isRequired,
   }).isRequired, // Object representing the selected method's data
-  toolTipOpen: PropTypes.arrayOf(PropTypes.bool).isRequired, // Array of booleans to manage tooltip state
-  setToolTipOpen: PropTypes.func.isRequired, // Function to update the tooltip state
 };

--- a/src/components/MainPage.js
+++ b/src/components/MainPage.js
@@ -20,6 +20,7 @@ import MainPageHeader from "./MainPageComponents/MainPageHeader";
 import { BLOCK_CLASS, PRODUCTS, UNIQUE_OS_NAMES } from "../helpers/consts";
 import MainPageMethodDropdown from "./MainPageComponents/MainPageMethodDropDown";
 import MainPageOSDropdown from "./MainPageComponents/MainPageOSDropDown";
+import {useTooltip} from '../context/TooltipContext';
 
 
 import "./../styles/connection_doc.scss";
@@ -56,6 +57,9 @@ export default function MainPage() {
   //open - Open variable for modal when clicking a DataSourceCard
   const [open, setOpen] = useState(false);
 
+  //show/close tooltip
+  const { setOpenTooltipId } = useTooltip();
+
   //selectedDataSourceData - DataSourceData selected for open modal
   const [selectedDataSourceData, setSelectedDataSourceData] = useState(null);
 
@@ -63,6 +67,10 @@ export default function MainPage() {
 
   const [selectedOS, setSelectedOS] = useState("All");
 
+
+  const handleClickAnywhere = () => {
+    setOpenTooltipId(null); // close any tooltip
+  };
 
   const handleSearchAndFilter = useCallback(() => {
     let searchedConnectionData = handleSearchBar(searchValue, fullConnectionData);
@@ -85,7 +93,7 @@ export default function MainPage() {
   return connectionData ? (
     <>
       {/* Main Container when Loaded */}
-      <div className="MainPageWrapper">
+      <div className="MainPageWrapper" onClick={handleClickAnywhere}>
         <MainPageHeader />
         {/* Divider */}
         <hr className="mainPageDivider" />

--- a/src/context/TooltipContext.js
+++ b/src/context/TooltipContext.js
@@ -1,0 +1,17 @@
+import { createContext, useContext, useState } from 'react';
+import React from "react";
+
+
+const TooltipContext = createContext();
+
+export function TooltipProvider({ children }){
+  const [openTooltipId, setOpenTooltipId] = useState(null); // e.g., 'link1', 'link2'
+
+  return (
+    <TooltipContext.Provider value={{ openTooltipId, setOpenTooltipId }}>
+      {children}
+    </TooltipContext.Provider>
+  );
+}
+
+export const useTooltip = () => useContext(TooltipContext);


### PR DESCRIPTION
fixed 2 UI issues:
When we click somewhere else in the page, popup should close

When we click x button to close “Detailed support information“ page and reopen it, we should also see that popup is closed, not open